### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715930644,
-        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
+        "lastModified": 1716736760,
+        "narHash": "sha256-h3RmnNknKYtVA+EvUSra6QAwfZjC2q1G8YA7W0gat8Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
+        "rev": "5d151429e1e79107acf6d06dcc5ace4e642ec239",
         "type": "github"
       },
       "original": {
@@ -128,11 +128,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1716311836,
-        "narHash": "sha256-HWsl4uUqEOvrvm8QCNKJWBP2xB3irsy+xMvyvLVHITk=",
+        "lastModified": 1716658811,
+        "narHash": "sha256-tJ/roE0BqzO2Sn73fF+50RpYYrRS5hDCHI8BmiuPMjA=",
         "owner": "hyprwm",
         "repo": "hyprpaper",
-        "rev": "678d0e8959cf7adbc3825d578595e82305573991",
+        "rev": "2c57525de840e4edada2cfd2924659b80f513ece",
         "type": "github"
       },
       "original": {
@@ -175,11 +175,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1716293225,
-        "narHash": "sha256-pU9ViBVE3XYb70xZx+jK6SEVphvt7xMTbm6yDIF4xPs=",
+        "lastModified": 1716509168,
+        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3eaeaeb6b1e08a016380c279f8846e0bd8808916",
+        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/e3ad5108f54177e6520535768ddbf1e6af54b59d' (2024-05-17)
  → 'github:nix-community/home-manager/5d151429e1e79107acf6d06dcc5ace4e642ec239' (2024-05-26)
• Updated input 'hyprpaper':
    'github:hyprwm/hyprpaper/678d0e8959cf7adbc3825d578595e82305573991' (2024-05-21)
  → 'github:hyprwm/hyprpaper/2c57525de840e4edada2cfd2924659b80f513ece' (2024-05-25)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3eaeaeb6b1e08a016380c279f8846e0bd8808916' (2024-05-21)
  → 'github:nixos/nixpkgs/bfb7a882678e518398ce9a31a881538679f6f092' (2024-05-24)

```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`3eaeaeb6` ➡️ `bfb7a882`](https://github.com/nixos/nixpkgs/compare/3eaeaeb6b1e08a016380c279f8846e0bd8808916...bfb7a882678e518398ce9a31a881538679f6f092) <sub>(2024-05-21 to 2024-05-24)</sub>
 - Updated input [`hyprpaper`](https://github.com/hyprwm/hyprpaper): [`678d0e89` ➡️ `2c57525d`](https://github.com/hyprwm/hyprpaper/compare/678d0e8959cf7adbc3825d578595e82305573991...2c57525de840e4edada2cfd2924659b80f513ece) <sub>(2024-05-21 to 2024-05-25)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`e3ad5108` ➡️ `5d151429`](https://github.com/nix-community/home-manager/compare/e3ad5108f54177e6520535768ddbf1e6af54b59d...5d151429e1e79107acf6d06dcc5ace4e642ec239) <sub>(2024-05-17 to 2024-05-26)</sub>