### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715930644,
-        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
+        "lastModified": 1717097707,
+        "narHash": "sha256-HC5vJ3oYsjwsCaSbkIPv80e4ebJpNvFKQTBOGlHvjLs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
+        "rev": "0eb314b4f0ba337e88123e0b1e57ef58346aafd9",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715636322,
-        "narHash": "sha256-66UJUns0ZEk3TdvUi0+4WY9nhTFZusSPca1saM8JbiI=",
+        "lastModified": 1716889749,
+        "narHash": "sha256-fn4s+gulS7ouxUJpuVkvTL6/ybTCOoMU1bov60E1NAE=",
         "owner": "Jappie3",
         "repo": "hyprcursor-phinger",
-        "rev": "3b8f975e16ffb6ff18ccf86481e6274a8d08893b",
+        "rev": "52980f831b3667e49eb2717c74eb0851f104d63e",
         "type": "github"
       },
       "original": {
@@ -128,11 +128,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1716311836,
-        "narHash": "sha256-HWsl4uUqEOvrvm8QCNKJWBP2xB3irsy+xMvyvLVHITk=",
+        "lastModified": 1716658811,
+        "narHash": "sha256-tJ/roE0BqzO2Sn73fF+50RpYYrRS5hDCHI8BmiuPMjA=",
         "owner": "hyprwm",
         "repo": "hyprpaper",
-        "rev": "678d0e8959cf7adbc3825d578595e82305573991",
+        "rev": "2c57525de840e4edada2cfd2924659b80f513ece",
         "type": "github"
       },
       "original": {
@@ -175,11 +175,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1716293225,
-        "narHash": "sha256-pU9ViBVE3XYb70xZx+jK6SEVphvt7xMTbm6yDIF4xPs=",
+        "lastModified": 1716948383,
+        "narHash": "sha256-SzDKxseEcHR5KzPXLwsemyTR/kaM9whxeiJohbL04rs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3eaeaeb6b1e08a016380c279f8846e0bd8808916",
+        "rev": "ad57eef4ef0659193044870c731987a6df5cf56b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/e3ad5108f54177e6520535768ddbf1e6af54b59d' (2024-05-17)
  → 'github:nix-community/home-manager/0eb314b4f0ba337e88123e0b1e57ef58346aafd9' (2024-05-30)
• Updated input 'hyprcursor-phinger':
    'github:Jappie3/hyprcursor-phinger/3b8f975e16ffb6ff18ccf86481e6274a8d08893b' (2024-05-13)
  → 'github:Jappie3/hyprcursor-phinger/52980f831b3667e49eb2717c74eb0851f104d63e' (2024-05-28)
• Updated input 'hyprpaper':
    'github:hyprwm/hyprpaper/678d0e8959cf7adbc3825d578595e82305573991' (2024-05-21)
  → 'github:hyprwm/hyprpaper/2c57525de840e4edada2cfd2924659b80f513ece' (2024-05-25)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3eaeaeb6b1e08a016380c279f8846e0bd8808916' (2024-05-21)
  → 'github:nixos/nixpkgs/ad57eef4ef0659193044870c731987a6df5cf56b' (2024-05-29)

```

</p></details>

 - Updated input [`hyprcursor-phinger`](https://github.com/Jappie3/hyprcursor-phinger): [`3b8f975e` ➡️ `52980f83`](https://github.com/Jappie3/hyprcursor-phinger/compare/3b8f975e16ffb6ff18ccf86481e6274a8d08893b...52980f831b3667e49eb2717c74eb0851f104d63e) <sub>(2024-05-13 to 2024-05-28)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`3eaeaeb6` ➡️ `ad57eef4`](https://github.com/nixos/nixpkgs/compare/3eaeaeb6b1e08a016380c279f8846e0bd8808916...ad57eef4ef0659193044870c731987a6df5cf56b) <sub>(2024-05-21 to 2024-05-29)</sub>
 - Updated input [`hyprpaper`](https://github.com/hyprwm/hyprpaper): [`678d0e89` ➡️ `2c57525d`](https://github.com/hyprwm/hyprpaper/compare/678d0e8959cf7adbc3825d578595e82305573991...2c57525de840e4edada2cfd2924659b80f513ece) <sub>(2024-05-21 to 2024-05-25)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`e3ad5108` ➡️ `0eb314b4`](https://github.com/nix-community/home-manager/compare/e3ad5108f54177e6520535768ddbf1e6af54b59d...0eb314b4f0ba337e88123e0b1e57ef58346aafd9) <sub>(2024-05-17 to 2024-05-30)</sub>