### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,14 +23,15 @@
         "flake-parts": "flake-parts",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1713259062,
-        "narHash": "sha256-WTO84hUL8IlNuHDK2yOCeJ38EewFzGt5E0kzBjNWxa8=",
+        "lastModified": 1717576207,
+        "narHash": "sha256-LU6d1xX7jN1zt10YU7Oym07MtzVfziSmUEznGFdbuaw=",
         "owner": "Kirottu",
         "repo": "anyrun",
-        "rev": "f9d30e34fa4ccb2797c6becec37e8bcff6585d39",
+        "rev": "7aabad8d5bb7d1bffae903ce86427b888ab824b4",
         "type": "github"
       },
       "original": {
@@ -47,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696343447,
-        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "lastModified": 1717285511,
+        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
         "type": "github"
       },
       "original": {
@@ -67,11 +68,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715930644,
-        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
+        "lastModified": 1717525419,
+        "narHash": "sha256-5z2422pzWnPXHgq2ms8lcCfttM0dz+hg+x1pCcNkAws=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
+        "rev": "a7117efb3725e6197dd95424136f79147aa35e5b",
         "type": "github"
       },
       "original": {
@@ -83,7 +84,7 @@
     "hyprlang": {
       "inputs": {
         "nixpkgs": "nixpkgs_2",
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1713121246,
@@ -105,14 +106,14 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_2"
+        "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1716311836,
-        "narHash": "sha256-HWsl4uUqEOvrvm8QCNKJWBP2xB3irsy+xMvyvLVHITk=",
+        "lastModified": 1717773598,
+        "narHash": "sha256-VpVrY2EHo7uF9OC5C10tNxMXDoDf+VmoW4HRVlpv3TE=",
         "owner": "hyprwm",
         "repo": "hyprpaper",
-        "rev": "678d0e8959cf7adbc3825d578595e82305573991",
+        "rev": "374d6e2a9d3ec86ea3f8d8613f9c47c96f596f6a",
         "type": "github"
       },
       "original": {
@@ -155,11 +156,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1716293225,
-        "narHash": "sha256-pU9ViBVE3XYb70xZx+jK6SEVphvt7xMTbm6yDIF4xPs=",
+        "lastModified": 1717602782,
+        "narHash": "sha256-pL9jeus5QpX5R+9rsp3hhZ+uplVHscNJh8n8VpqscM0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3eaeaeb6b1e08a016380c279f8846e0bd8808916",
+        "rev": "e8057b67ebf307f01bdcc8fba94d94f75039d1f6",
         "type": "github"
       },
       "original": {
@@ -194,6 +195,21 @@
       }
     },
     "systems_2": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1689347949,
         "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'anyrun':
    'github:Kirottu/anyrun/f9d30e34fa4ccb2797c6becec37e8bcff6585d39' (2024-04-16)
  → 'github:Kirottu/anyrun/7aabad8d5bb7d1bffae903ce86427b888ab824b4' (2024-06-05)
• Updated input 'anyrun/flake-parts':
    'github:hercules-ci/flake-parts/c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4' (2023-10-03)
  → 'github:hercules-ci/flake-parts/2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8' (2024-06-01)
• Added input 'anyrun/systems':
    'github:nix-systems/default-linux/31732fcf5e8fea42e59c2488ad31a0e651500f68' (2023-07-14)
• Updated input 'home-manager':
    'github:nix-community/home-manager/e3ad5108f54177e6520535768ddbf1e6af54b59d' (2024-05-17)
  → 'github:nix-community/home-manager/a7117efb3725e6197dd95424136f79147aa35e5b' (2024-06-04)
• Updated input 'hyprpaper':
    'github:hyprwm/hyprpaper/678d0e8959cf7adbc3825d578595e82305573991' (2024-05-21)
  → 'github:hyprwm/hyprpaper/374d6e2a9d3ec86ea3f8d8613f9c47c96f596f6a' (2024-06-07)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3eaeaeb6b1e08a016380c279f8846e0bd8808916' (2024-05-21)
  → 'github:nixos/nixpkgs/e8057b67ebf307f01bdcc8fba94d94f75039d1f6' (2024-06-05)

```

</p></details>

 - Updated input [`anyrun/flake-parts`](https://github.com/hercules-ci/flake-parts): [`c9afaba3` ➡️ `2a55567f`](https://github.com/hercules-ci/flake-parts/compare/c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4...2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8) <sub>(2023-10-03 to 2024-06-01)</sub>
 - Added input [`anyrun/systems`](https://github.com/nix-systems/default-linux): [github.com/nix-systems/default-linux](https://github.com/nix-systems/default-linux/tree/31732fcf5e8fea42e59c2488ad31a0e651500f68/)
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`3eaeaeb6` ➡️ `e8057b67`](https://github.com/nixos/nixpkgs/compare/3eaeaeb6b1e08a016380c279f8846e0bd8808916...e8057b67ebf307f01bdcc8fba94d94f75039d1f6) <sub>(2024-05-21 to 2024-06-05)</sub>
 - Updated input [`hyprpaper`](https://github.com/hyprwm/hyprpaper): [`678d0e89` ➡️ `374d6e2a`](https://github.com/hyprwm/hyprpaper/compare/678d0e8959cf7adbc3825d578595e82305573991...374d6e2a9d3ec86ea3f8d8613f9c47c96f596f6a) <sub>(2024-05-21 to 2024-06-07)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`e3ad5108` ➡️ `a7117efb`](https://github.com/nix-community/home-manager/compare/e3ad5108f54177e6520535768ddbf1e6af54b59d...a7117efb3725e6197dd95424136f79147aa35e5b) <sub>(2024-05-17 to 2024-06-04)</sub>
 - Updated input [`anyrun`](https://github.com/Kirottu/anyrun): [`f9d30e34` ➡️ `7aabad8d`](https://github.com/Kirottu/anyrun/compare/f9d30e34fa4ccb2797c6becec37e8bcff6585d39...7aabad8d5bb7d1bffae903ce86427b888ab824b4) <sub>(2024-04-16 to 2024-06-05)</sub>