### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,14 +2,15 @@
   "nodes": {
     "ags": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1715703984,
-        "narHash": "sha256-0BZkMui6aCqswMCouvp0G90tAxDOxVnxTvG6TDZsDaI=",
+        "lastModified": 1721306136,
+        "narHash": "sha256-VKPsIGf3/a+RONBipx4lEE4LXG2sdMNkWQu22LNQItg=",
         "owner": "Aylur",
         "repo": "ags",
-        "rev": "11150225e62462bcd431d1e55185e810190a730a",
+        "rev": "344ea72cd3b8d4911f362fec34bce7d8fb37028c",
         "type": "github"
       },
       "original": {
@@ -24,14 +25,14 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1717576207,
-        "narHash": "sha256-LU6d1xX7jN1zt10YU7Oym07MtzVfziSmUEznGFdbuaw=",
+        "lastModified": 1721135360,
+        "narHash": "sha256-ZhSA0e45UxiOAjEVqkym/aULh0Dt+KHJLNda7bjx9UI=",
         "owner": "Kirottu",
         "repo": "anyrun",
-        "rev": "7aabad8d5bb7d1bffae903ce86427b888ab824b4",
+        "rev": "c6101a31a80b51e32e96f6a77616b609770172e0",
         "type": "github"
       },
       "original": {
@@ -195,11 +196,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717525419,
-        "narHash": "sha256-5z2422pzWnPXHgq2ms8lcCfttM0dz+hg+x1pCcNkAws=",
+        "lastModified": 1721804110,
+        "narHash": "sha256-i4jINRazBKPqlaS+qhlP+kV/UHEq3vs5itfpblqu4ZM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a7117efb3725e6197dd95424136f79147aa35e5b",
+        "rev": "af70fc502a15d7e1e4c5a4c4fc8e06c2ec561e0c",
         "type": "github"
       },
       "original": {
@@ -210,15 +211,25 @@
     },
     "hyprlang": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3",
-        "systems": "systems_2"
+        "hyprutils": [
+          "hyprpaper",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "hyprpaper",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprpaper",
+          "systems"
+        ]
       },
       "locked": {
-        "lastModified": 1713121246,
-        "narHash": "sha256-502X0Q0fhN6tJK7iEUA8CghONKSatW/Mqj4Wappd++0=",
+        "lastModified": 1721324361,
+        "narHash": "sha256-BiJKO0IIdnSwHQBSrEJlKlFr753urkLE48wtt0UhNG4=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "78fcaa27ae9e1d782faa3ff06c8ea55ddce63706",
+        "rev": "adbefbf49664a6c2c8bf36b6487fd31e3eb68086",
         "type": "github"
       },
       "original": {
@@ -230,22 +241,74 @@
     "hyprpaper": {
       "inputs": {
         "hyprlang": "hyprlang",
+        "hyprutils": "hyprutils",
+        "hyprwayland-scanner": "hyprwayland-scanner",
         "nixpkgs": [
           "nixpkgs"
         ],
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1717773598,
-        "narHash": "sha256-VpVrY2EHo7uF9OC5C10tNxMXDoDf+VmoW4HRVlpv3TE=",
+        "lastModified": 1721686135,
+        "narHash": "sha256-Hu2r0BX0/98FzNXI5Nmr+Y0C03iymd+TBiCdR8poW+M=",
         "owner": "hyprwm",
         "repo": "hyprpaper",
-        "rev": "374d6e2a9d3ec86ea3f8d8613f9c47c96f596f6a",
+        "rev": "f1f7fc60f5ae2609a369964aeb7ddbf6f9277de7",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "hyprpaper",
+        "type": "github"
+      }
+    },
+    "hyprutils": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprpaper",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprpaper",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1721324102,
+        "narHash": "sha256-WAZ0X6yJW1hFG6otkHBfyJDKRpNP5stsRqdEuHrFRpk=",
+        "owner": "hyprwm",
+        "repo": "hyprutils",
+        "rev": "962582a090bc233c4de9d9897f46794280288989",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprutils",
+        "type": "github"
+      }
+    },
+    "hyprwayland-scanner": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprpaper",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprpaper",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1721324119,
+        "narHash": "sha256-SOOqIT27/X792+vsLSeFdrNTF+OSRp5qXv6Te+fb2Qg=",
+        "owner": "hyprwm",
+        "repo": "hyprwayland-scanner",
+        "rev": "a048a6cb015340bd82f97c1f40a4b595ca85cc30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprwayland-scanner",
         "type": "github"
       }
     },
@@ -280,11 +343,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1721754224,
-        "narHash": "sha256-JEVfxzZRo+/zdWKBjHpAUG905SDZL9fmoLJxf9b5CGU=",
+        "lastModified": 1721839713,
+        "narHash": "sha256-apTv16L9h5ONS2VTPbKEgwAOVmWGku0MsfprjgwBFHo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "405b654893aba16c8014de6a17e84439d3fb8e46",
+        "rev": "a7432ebaefc9a400dcda399d48b949230378d784",
         "type": "github"
       },
       "original": {
@@ -339,11 +402,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708475490,
-        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
+        "lastModified": 1718714799,
+        "narHash": "sha256-FUZpz9rg3gL8NVPKbqU8ei1VkPLsTIfAJ2fdAf5qjak=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
+        "rev": "c00d587b1a1afbf200b1d8f0b0e4ba9deb1c7f0e",
         "type": "github"
       },
       "original": {
@@ -384,27 +447,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1708475490,
-        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1717602782,
-        "narHash": "sha256-pL9jeus5QpX5R+9rsp3hhZ+uplVHscNJh8n8VpqscM0=",
+        "lastModified": 1721562059,
+        "narHash": "sha256-Tybxt65eyOARf285hMHIJ2uul8SULjFZbT9ZaEeUnP8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e8057b67ebf307f01bdcc8fba94d94f75039d1f6",
+        "rev": "68c9ed8bbed9dfce253cc91560bf9043297ef2fe",
         "type": "github"
       },
       "original": {
@@ -423,7 +470,7 @@
         "home-manager": "home-manager_2",
         "hyprpaper": "hyprpaper",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "sops-nix": "sops-nix"
       }
     },


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'ags':
    'github:Aylur/ags/11150225e62462bcd431d1e55185e810190a730a' (2024-05-14)
  → 'github:Aylur/ags/344ea72cd3b8d4911f362fec34bce7d8fb37028c' (2024-07-18)
• Updated input 'ags/nixpkgs':
    'github:NixOS/nixpkgs/0e74ca98a74bc7270d28838369593635a5db3260' (2024-02-21)
  → 'github:NixOS/nixpkgs/c00d587b1a1afbf200b1d8f0b0e4ba9deb1c7f0e' (2024-06-18)
• Added input 'ags/systems':
    'github:nix-systems/default-linux/31732fcf5e8fea42e59c2488ad31a0e651500f68' (2023-07-14)
• Updated input 'anyrun':
    'github:Kirottu/anyrun/7aabad8d5bb7d1bffae903ce86427b888ab824b4' (2024-06-05)
  → 'github:Kirottu/anyrun/c6101a31a80b51e32e96f6a77616b609770172e0' (2024-07-16)
• Updated input 'home-manager':
    'github:nix-community/home-manager/a7117efb3725e6197dd95424136f79147aa35e5b' (2024-06-04)
  → 'github:nix-community/home-manager/af70fc502a15d7e1e4c5a4c4fc8e06c2ec561e0c' (2024-07-24)
• Updated input 'hyprpaper':
    'github:hyprwm/hyprpaper/374d6e2a9d3ec86ea3f8d8613f9c47c96f596f6a' (2024-06-07)
  → 'github:hyprwm/hyprpaper/f1f7fc60f5ae2609a369964aeb7ddbf6f9277de7' (2024-07-22)
• Updated input 'hyprpaper/hyprlang':
    'github:hyprwm/hyprlang/78fcaa27ae9e1d782faa3ff06c8ea55ddce63706' (2024-04-14)
  → 'github:hyprwm/hyprlang/adbefbf49664a6c2c8bf36b6487fd31e3eb68086' (2024-07-18)
• Added input 'hyprpaper/hyprlang/hyprutils':
    follows 'hyprpaper/hyprutils'
• Updated input 'hyprpaper/hyprlang/nixpkgs':
    'github:NixOS/nixpkgs/0e74ca98a74bc7270d28838369593635a5db3260' (2024-02-21)
  → follows 'hyprpaper/nixpkgs'
• Updated input 'hyprpaper/hyprlang/systems':
    'github:nix-systems/default-linux/31732fcf5e8fea42e59c2488ad31a0e651500f68' (2023-07-14)
  → follows 'hyprpaper/systems'
• Added input 'hyprpaper/hyprutils':
    'github:hyprwm/hyprutils/962582a090bc233c4de9d9897f46794280288989' (2024-07-18)
• Added input 'hyprpaper/hyprutils/nixpkgs':
    follows 'hyprpaper/nixpkgs'
• Added input 'hyprpaper/hyprutils/systems':
    follows 'hyprpaper/systems'
• Added input 'hyprpaper/hyprwayland-scanner':
    'github:hyprwm/hyprwayland-scanner/a048a6cb015340bd82f97c1f40a4b595ca85cc30' (2024-07-18)
• Added input 'hyprpaper/hyprwayland-scanner/nixpkgs':
    follows 'hyprpaper/nixpkgs'
• Added input 'hyprpaper/hyprwayland-scanner/systems':
    follows 'hyprpaper/systems'
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/405b654893aba16c8014de6a17e84439d3fb8e46' (2024-07-23)
  → 'github:NixOS/nixos-hardware/a7432ebaefc9a400dcda399d48b949230378d784' (2024-07-24)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e8057b67ebf307f01bdcc8fba94d94f75039d1f6' (2024-06-05)
  → 'github:nixos/nixpkgs/68c9ed8bbed9dfce253cc91560bf9043297ef2fe' (2024-07-21)

```

</p></details>

 - Added input `hyprpaper/hyprwayland-scanner/nixpkgs`: ``
 - Updated input [`ags`](https://github.com/Aylur/ags): [`11150225` ➡️ `344ea72c`](https://github.com/Aylur/ags/compare/11150225e62462bcd431d1e55185e810190a730a...344ea72cd3b8d4911f362fec34bce7d8fb37028c) <sub>(2024-05-14 to 2024-07-18)</sub>
 - Updated input [`hyprpaper/hyprlang`](https://github.com/hyprwm/hyprlang): [`78fcaa27` ➡️ `adbefbf4`](https://github.com/hyprwm/hyprlang/compare/78fcaa27ae9e1d782faa3ff06c8ea55ddce63706...adbefbf49664a6c2c8bf36b6487fd31e3eb68086) <sub>(2024-04-14 to 2024-07-18)</sub>
 - Updated input [`ags/nixpkgs`](https://github.com/NixOS/nixpkgs): [`0e74ca98` ➡️ `c00d587b`](https://github.com/NixOS/nixpkgs/compare/0e74ca98a74bc7270d28838369593635a5db3260...c00d587b1a1afbf200b1d8f0b0e4ba9deb1c7f0e) <sub>(2024-02-21 to 2024-06-18)</sub>
 - Added input [`hyprpaper/hyprwayland-scanner`](https://github.com/hyprwm/hyprwayland-scanner): [github.com/hyprwm/hyprwayland-scanner](https://github.com/hyprwm/hyprwayland-scanner/tree/a048a6cb015340bd82f97c1f40a4b595ca85cc30/)
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`e8057b67` ➡️ `68c9ed8b`](https://github.com/nixos/nixpkgs/compare/e8057b67ebf307f01bdcc8fba94d94f75039d1f6...68c9ed8bbed9dfce253cc91560bf9043297ef2fe) <sub>(2024-06-05 to 2024-07-21)</sub>
 - Added input [`hyprpaper/hyprutils`](https://github.com/hyprwm/hyprutils): [github.com/hyprwm/hyprutils](https://github.com/hyprwm/hyprutils/tree/962582a090bc233c4de9d9897f46794280288989/)
 - Updated input `hyprpaper/hyprlang/systems`: `31732fcf` ➡️ `` <sub>(2023-07-14 to )</sub>
 - Updated input [`hyprpaper`](https://github.com/hyprwm/hyprpaper): [`374d6e2a` ➡️ `f1f7fc60`](https://github.com/hyprwm/hyprpaper/compare/374d6e2a9d3ec86ea3f8d8613f9c47c96f596f6a...f1f7fc60f5ae2609a369964aeb7ddbf6f9277de7) <sub>(2024-06-07 to 2024-07-22)</sub>
 - Added input `hyprpaper/hyprutils/systems`: ``
 - Added input `hyprpaper/hyprwayland-scanner/systems`: ``
 - Updated input `hyprpaper/hyprlang/nixpkgs`: `0e74ca98` ➡️ `` <sub>(2024-02-21 to )</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`a7117efb` ➡️ `af70fc50`](https://github.com/nix-community/home-manager/compare/a7117efb3725e6197dd95424136f79147aa35e5b...af70fc502a15d7e1e4c5a4c4fc8e06c2ec561e0c) <sub>(2024-06-04 to 2024-07-24)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`405b6548` ➡️ `a7432eba`](https://github.com/NixOS/nixos-hardware/compare/405b654893aba16c8014de6a17e84439d3fb8e46...a7432ebaefc9a400dcda399d48b949230378d784) <sub>(2024-07-23 to 2024-07-24)</sub>
 - Added input `hyprpaper/hyprutils/nixpkgs`: ``
 - Added input `hyprpaper/hyprlang/hyprutils`: ``
 - Updated input [`anyrun`](https://github.com/Kirottu/anyrun): [`7aabad8d` ➡️ `c6101a31`](https://github.com/Kirottu/anyrun/compare/7aabad8d5bb7d1bffae903ce86427b888ab824b4...c6101a31a80b51e32e96f6a77616b609770172e0) <sub>(2024-06-05 to 2024-07-16)</sub>
 - Added input [`ags/systems`](https://github.com/nix-systems/default-linux): [github.com/nix-systems/default-linux](https://github.com/nix-systems/default-linux/tree/31732fcf5e8fea42e59c2488ad31a0e651500f68/)