### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721735625,
-        "narHash": "sha256-4T0FK0b3Q7Dd7oj79M7GhA9+YqKxxGT0iN+h8yqdP7s=",
+        "lastModified": 1722476845,
+        "narHash": "sha256-7gZ8uf3qOox8Vrwd+p9EhUHHLhhK8lis/5KcXGmIaow=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "4698b1ef375e9c904037e0b2049aa73d39ac1b2d",
+        "rev": "7e1b215a0a96efb306ad6440bf706d2b307dc267",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721804110,
-        "narHash": "sha256-i4jINRazBKPqlaS+qhlP+kV/UHEq3vs5itfpblqu4ZM=",
+        "lastModified": 1722630065,
+        "narHash": "sha256-QfM/9BMRkCmgWzrPDK+KbgJOUlSJnfX4OvsUupEUZvA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "af70fc502a15d7e1e4c5a4c4fc8e06c2ec561e0c",
+        "rev": "afc892db74d65042031a093adb6010c4c3378422",
         "type": "github"
       },
       "original": {
@@ -343,11 +343,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1721839713,
-        "narHash": "sha256-apTv16L9h5ONS2VTPbKEgwAOVmWGku0MsfprjgwBFHo=",
+        "lastModified": 1722332872,
+        "narHash": "sha256-2xLM4sc5QBfi0U/AANJAW21Bj4ZX479MHPMPkB+eKBU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a7432ebaefc9a400dcda399d48b949230378d784",
+        "rev": "14c333162ba53c02853add87a0000cbd7aa230c2",
         "type": "github"
       },
       "original": {
@@ -447,11 +447,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1721562059,
-        "narHash": "sha256-Tybxt65eyOARf285hMHIJ2uul8SULjFZbT9ZaEeUnP8=",
+        "lastModified": 1722421184,
+        "narHash": "sha256-/DJBI6trCeVnasdjUo9pbnodCLZcFqnVZiLUfqLH4jA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "68c9ed8bbed9dfce253cc91560bf9043297ef2fe",
+        "rev": "9f918d616c5321ad374ae6cb5ea89c9e04bf3e58",
         "type": "github"
       },
       "original": {
@@ -482,11 +482,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721688883,
-        "narHash": "sha256-9jsjsRKtJRqNSTXKj9zuDFRf2PGix30nMx9VKyPgD2U=",
+        "lastModified": 1722114803,
+        "narHash": "sha256-s6YhI8UHwQvO4cIFLwl1wZ1eS5Cuuw7ld2VzUchdFP0=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "aff2f88277dabe695de4773682842c34a0b7fd54",
+        "rev": "eb34eb588132d653e4c4925d862f1e5a227cc2ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/4698b1ef375e9c904037e0b2049aa73d39ac1b2d' (2024-07-23)
  → 'github:nix-community/disko/7e1b215a0a96efb306ad6440bf706d2b307dc267' (2024-08-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/af70fc502a15d7e1e4c5a4c4fc8e06c2ec561e0c' (2024-07-24)
  → 'github:nix-community/home-manager/afc892db74d65042031a093adb6010c4c3378422' (2024-08-02)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/a7432ebaefc9a400dcda399d48b949230378d784' (2024-07-24)
  → 'github:NixOS/nixos-hardware/14c333162ba53c02853add87a0000cbd7aa230c2' (2024-07-30)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/68c9ed8bbed9dfce253cc91560bf9043297ef2fe' (2024-07-21)
  → 'github:nixos/nixpkgs/9f918d616c5321ad374ae6cb5ea89c9e04bf3e58' (2024-07-31)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/aff2f88277dabe695de4773682842c34a0b7fd54' (2024-07-22)
  → 'github:Mic92/sops-nix/eb34eb588132d653e4c4925d862f1e5a227cc2ab' (2024-07-27)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`4698b1ef` ➡️ `7e1b215a`](https://github.com/nix-community/disko/compare/4698b1ef375e9c904037e0b2049aa73d39ac1b2d...7e1b215a0a96efb306ad6440bf706d2b307dc267) <sub>(2024-07-23 to 2024-08-01)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`68c9ed8b` ➡️ `9f918d61`](https://github.com/nixos/nixpkgs/compare/68c9ed8bbed9dfce253cc91560bf9043297ef2fe...9f918d616c5321ad374ae6cb5ea89c9e04bf3e58) <sub>(2024-07-21 to 2024-07-31)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`aff2f882` ➡️ `eb34eb58`](https://github.com/Mic92/sops-nix/compare/aff2f88277dabe695de4773682842c34a0b7fd54...eb34eb588132d653e4c4925d862f1e5a227cc2ab) <sub>(2024-07-22 to 2024-07-27)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`af70fc50` ➡️ `afc892db`](https://github.com/nix-community/home-manager/compare/af70fc502a15d7e1e4c5a4c4fc8e06c2ec561e0c...afc892db74d65042031a093adb6010c4c3378422) <sub>(2024-07-24 to 2024-08-02)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`a7432eba` ➡️ `14c33316`](https://github.com/NixOS/nixos-hardware/compare/a7432ebaefc9a400dcda399d48b949230378d784...14c333162ba53c02853add87a0000cbd7aa230c2) <sub>(2024-07-24 to 2024-07-30)</sub>