### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -127,11 +127,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721735625,
-        "narHash": "sha256-4T0FK0b3Q7Dd7oj79M7GhA9+YqKxxGT0iN+h8yqdP7s=",
+        "lastModified": 1722821805,
+        "narHash": "sha256-FGrUPUD+LMDwJsYyNSxNIzFMldtCm8wXiQuyL2PHSrM=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "4698b1ef375e9c904037e0b2049aa73d39ac1b2d",
+        "rev": "0257e44f4ad472b54f19a6dd1615aee7fa48ed49",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721804110,
-        "narHash": "sha256-i4jINRazBKPqlaS+qhlP+kV/UHEq3vs5itfpblqu4ZM=",
+        "lastModified": 1722936497,
+        "narHash": "sha256-UBst8PkhY0kqTgdKiR8MtTBt4c1XmjJoOV11efjsC/o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "af70fc502a15d7e1e4c5a4c4fc8e06c2ec561e0c",
+        "rev": "a6c743980e23f4cef6c2a377f9ffab506568413a",
         "type": "github"
       },
       "original": {
@@ -379,11 +379,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1721839713,
-        "narHash": "sha256-apTv16L9h5ONS2VTPbKEgwAOVmWGku0MsfprjgwBFHo=",
+        "lastModified": 1722332872,
+        "narHash": "sha256-2xLM4sc5QBfi0U/AANJAW21Bj4ZX479MHPMPkB+eKBU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a7432ebaefc9a400dcda399d48b949230378d784",
+        "rev": "14c333162ba53c02853add87a0000cbd7aa230c2",
         "type": "github"
       },
       "original": {
@@ -483,11 +483,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1721562059,
-        "narHash": "sha256-Tybxt65eyOARf285hMHIJ2uul8SULjFZbT9ZaEeUnP8=",
+        "lastModified": 1722813957,
+        "narHash": "sha256-IAoYyYnED7P8zrBFMnmp7ydaJfwTnwcnqxUElC1I26Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "68c9ed8bbed9dfce253cc91560bf9043297ef2fe",
+        "rev": "cb9a96f23c491c081b38eab96d22fa958043c9fa",
         "type": "github"
       },
       "original": {
@@ -536,11 +536,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721688883,
-        "narHash": "sha256-9jsjsRKtJRqNSTXKj9zuDFRf2PGix30nMx9VKyPgD2U=",
+        "lastModified": 1722897572,
+        "narHash": "sha256-3m/iyyjCdRBF8xyehf59QlckIcmShyTesymSb+N4Ap4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "aff2f88277dabe695de4773682842c34a0b7fd54",
+        "rev": "8ae477955dfd9cbf5fa4eb82a8db8ddbb94e79d9",
         "type": "github"
       },
       "original": {
@@ -622,11 +622,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1722787859,
-        "narHash": "sha256-Ul32555I36DDHXAxtwfAp1S5l857+CRjRcmzcc8D+ME=",
+        "lastModified": 1722940116,
+        "narHash": "sha256-cU6yNIhIWulGv7JFGRVn68l873csRcRToHNr8dQ2j2c=",
         "owner": "abenz1267",
         "repo": "walker",
-        "rev": "99b90d70003f3f2959b6aa99142bd595463fc54c",
+        "rev": "bed403b97ee0ba356428d78525a0a6294194ee98",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/4698b1ef375e9c904037e0b2049aa73d39ac1b2d' (2024-07-23)
  → 'github:nix-community/disko/0257e44f4ad472b54f19a6dd1615aee7fa48ed49' (2024-08-05)
• Updated input 'home-manager':
    'github:nix-community/home-manager/af70fc502a15d7e1e4c5a4c4fc8e06c2ec561e0c' (2024-07-24)
  → 'github:nix-community/home-manager/a6c743980e23f4cef6c2a377f9ffab506568413a' (2024-08-06)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/a7432ebaefc9a400dcda399d48b949230378d784' (2024-07-24)
  → 'github:NixOS/nixos-hardware/14c333162ba53c02853add87a0000cbd7aa230c2' (2024-07-30)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/68c9ed8bbed9dfce253cc91560bf9043297ef2fe' (2024-07-21)
  → 'github:nixos/nixpkgs/cb9a96f23c491c081b38eab96d22fa958043c9fa' (2024-08-04)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/aff2f88277dabe695de4773682842c34a0b7fd54' (2024-07-22)
  → 'github:Mic92/sops-nix/8ae477955dfd9cbf5fa4eb82a8db8ddbb94e79d9' (2024-08-05)
• Updated input 'walker':
    'github:abenz1267/walker/99b90d70003f3f2959b6aa99142bd595463fc54c' (2024-08-04)
  → 'github:abenz1267/walker/bed403b97ee0ba356428d78525a0a6294194ee98' (2024-08-06)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`4698b1ef` ➡️ `0257e44f`](https://github.com/nix-community/disko/compare/4698b1ef375e9c904037e0b2049aa73d39ac1b2d...0257e44f4ad472b54f19a6dd1615aee7fa48ed49) <sub>(2024-07-23 to 2024-08-05)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`68c9ed8b` ➡️ `cb9a96f2`](https://github.com/nixos/nixpkgs/compare/68c9ed8bbed9dfce253cc91560bf9043297ef2fe...cb9a96f23c491c081b38eab96d22fa958043c9fa) <sub>(2024-07-21 to 2024-08-04)</sub>
 - Updated input [`walker`](https://github.com/abenz1267/walker): [`99b90d70` ➡️ `bed403b9`](https://github.com/abenz1267/walker/compare/99b90d70003f3f2959b6aa99142bd595463fc54c...bed403b97ee0ba356428d78525a0a6294194ee98) <sub>(2024-08-04 to 2024-08-06)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`aff2f882` ➡️ `8ae47795`](https://github.com/Mic92/sops-nix/compare/aff2f88277dabe695de4773682842c34a0b7fd54...8ae477955dfd9cbf5fa4eb82a8db8ddbb94e79d9) <sub>(2024-07-22 to 2024-08-05)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`af70fc50` ➡️ `a6c74398`](https://github.com/nix-community/home-manager/compare/af70fc502a15d7e1e4c5a4c4fc8e06c2ec561e0c...a6c743980e23f4cef6c2a377f9ffab506568413a) <sub>(2024-07-24 to 2024-08-06)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`a7432eba` ➡️ `14c33316`](https://github.com/NixOS/nixos-hardware/compare/a7432ebaefc9a400dcda399d48b949230378d784...14c333162ba53c02853add87a0000cbd7aa230c2) <sub>(2024-07-24 to 2024-07-30)</sub>