### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1722661201,
-        "narHash": "sha256-2JX3S1hmmUhHuyGyGWnaM4xT0SiaDdVkNzmBrEowwK0=",
+        "lastModified": 1722997334,
+        "narHash": "sha256-vE5FcKVQ3E0txJKt5w3vOlfcN1XoTAlxK9PnQ/CJavA=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "19a0f144f0204a12a89243363efb6a493b8cfc83",
+        "rev": "66f4ea170093b62f319f41cebd2337a51b225c5a",
         "type": "github"
       },
       "original": {
@@ -127,11 +127,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722821805,
-        "narHash": "sha256-FGrUPUD+LMDwJsYyNSxNIzFMldtCm8wXiQuyL2PHSrM=",
+        "lastModified": 1723080788,
+        "narHash": "sha256-C5LbM5VMdcolt9zHeLQ0bYMRjUL+N+AL5pK7/tVTdes=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "0257e44f4ad472b54f19a6dd1615aee7fa48ed49",
+        "rev": "ffc1f95f6c28e1c6d1e587b51a2147027a3e45ed",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722936497,
-        "narHash": "sha256-UBst8PkhY0kqTgdKiR8MtTBt4c1XmjJoOV11efjsC/o=",
+        "lastModified": 1723015306,
+        "narHash": "sha256-jQnFEtH20/OsDPpx71ntZzGdRlpXhUENSQCGTjn//NA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a6c743980e23f4cef6c2a377f9ffab506568413a",
+        "rev": "b3d5ea65d88d67d4ec578ed11d4d2d51e3de525e",
         "type": "github"
       },
       "original": {
@@ -379,11 +379,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1722332872,
-        "narHash": "sha256-2xLM4sc5QBfi0U/AANJAW21Bj4ZX479MHPMPkB+eKBU=",
+        "lastModified": 1723149858,
+        "narHash": "sha256-3u51s7jdhavmEL1ggtd8wqrTH2clTy5yaZmhLvAXTqc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "14c333162ba53c02853add87a0000cbd7aa230c2",
+        "rev": "107bb46eef1f05e86fc485ee8af9b637e5157988",
         "type": "github"
       },
       "original": {
@@ -622,11 +622,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1722940116,
-        "narHash": "sha256-cU6yNIhIWulGv7JFGRVn68l873csRcRToHNr8dQ2j2c=",
+        "lastModified": 1723209718,
+        "narHash": "sha256-VDA7ui9ZarMNtHKsv8/N60rjtuTwPLdES7BH25B3YR4=",
         "owner": "abenz1267",
         "repo": "walker",
-        "rev": "bed403b97ee0ba356428d78525a0a6294194ee98",
+        "rev": "d1a8a2a0accbc3d773e6ef2eadecf75b78134e8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/19a0f144f0204a12a89243363efb6a493b8cfc83' (2024-08-03)
  → 'github:catppuccin/nix/66f4ea170093b62f319f41cebd2337a51b225c5a' (2024-08-07)
• Updated input 'disko':
    'github:nix-community/disko/0257e44f4ad472b54f19a6dd1615aee7fa48ed49' (2024-08-05)
  → 'github:nix-community/disko/ffc1f95f6c28e1c6d1e587b51a2147027a3e45ed' (2024-08-08)
• Updated input 'home-manager':
    'github:nix-community/home-manager/a6c743980e23f4cef6c2a377f9ffab506568413a' (2024-08-06)
  → 'github:nix-community/home-manager/b3d5ea65d88d67d4ec578ed11d4d2d51e3de525e' (2024-08-07)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/14c333162ba53c02853add87a0000cbd7aa230c2' (2024-07-30)
  → 'github:NixOS/nixos-hardware/107bb46eef1f05e86fc485ee8af9b637e5157988' (2024-08-08)
• Updated input 'walker':
    'github:abenz1267/walker/bed403b97ee0ba356428d78525a0a6294194ee98' (2024-08-06)
  → 'github:abenz1267/walker/d1a8a2a0accbc3d773e6ef2eadecf75b78134e8e' (2024-08-09)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`0257e44f` ➡️ `ffc1f95f`](https://github.com/nix-community/disko/compare/0257e44f4ad472b54f19a6dd1615aee7fa48ed49...ffc1f95f6c28e1c6d1e587b51a2147027a3e45ed) <sub>(2024-08-05 to 2024-08-08)</sub>
 - Updated input [`walker`](https://github.com/abenz1267/walker): [`bed403b9` ➡️ `d1a8a2a0`](https://github.com/abenz1267/walker/compare/bed403b97ee0ba356428d78525a0a6294194ee98...d1a8a2a0accbc3d773e6ef2eadecf75b78134e8e) <sub>(2024-08-06 to 2024-08-09)</sub>
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`19a0f144` ➡️ `66f4ea17`](https://github.com/catppuccin/nix/compare/19a0f144f0204a12a89243363efb6a493b8cfc83...66f4ea170093b62f319f41cebd2337a51b225c5a) <sub>(2024-08-03 to 2024-08-07)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`a6c74398` ➡️ `b3d5ea65`](https://github.com/nix-community/home-manager/compare/a6c743980e23f4cef6c2a377f9ffab506568413a...b3d5ea65d88d67d4ec578ed11d4d2d51e3de525e) <sub>(2024-08-06 to 2024-08-07)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`14c33316` ➡️ `107bb46e`](https://github.com/NixOS/nixos-hardware/compare/14c333162ba53c02853add87a0000cbd7aa230c2...107bb46eef1f05e86fc485ee8af9b637e5157988) <sub>(2024-07-30 to 2024-08-08)</sub>