### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -151,11 +151,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723080788,
-        "narHash": "sha256-C5LbM5VMdcolt9zHeLQ0bYMRjUL+N+AL5pK7/tVTdes=",
+        "lastModified": 1723426710,
+        "narHash": "sha256-yrS9al6l3fYfFfvovnyBWnyELDQOdfKyai4K/jKgoBw=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "ffc1f95f6c28e1c6d1e587b51a2147027a3e45ed",
+        "rev": "0d510fe40b56ed74907a021d7e1ffd0042592914",
         "type": "github"
       },
       "original": {
@@ -327,11 +327,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1721686135,
-        "narHash": "sha256-Hu2r0BX0/98FzNXI5Nmr+Y0C03iymd+TBiCdR8poW+M=",
+        "lastModified": 1723483862,
+        "narHash": "sha256-Ngo4erS1zcSBDDQOb3Rpeb09/uyK0GwZF+42AfX9yPw=",
         "owner": "hyprwm",
         "repo": "hyprpaper",
-        "rev": "f1f7fc60f5ae2609a369964aeb7ddbf6f9277de7",
+        "rev": "e32a2c8d246f166f5e454e26984e89028dcd3349",
         "type": "github"
       },
       "original": {
@@ -541,11 +541,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1723175592,
-        "narHash": "sha256-M0xJ3FbDUc4fRZ84dPGx5VvgFsOzds77KiBMW/mMTnI=",
+        "lastModified": 1723362943,
+        "narHash": "sha256-dFZRVSgmJkyM0bkPpaYRtG/kRMRTorUIDj8BxoOt1T4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
+        "rev": "a58bc8ad779655e790115244571758e8de055e3d",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722897572,
-        "narHash": "sha256-3m/iyyjCdRBF8xyehf59QlckIcmShyTesymSb+N4Ap4=",
+        "lastModified": 1723501126,
+        "narHash": "sha256-N9IcHgj/p1+2Pvk8P4Zc1bfrMwld5PcosVA0nL6IGdE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8ae477955dfd9cbf5fa4eb82a8db8ddbb94e79d9",
+        "rev": "be0eec2d27563590194a9206f551a6f73d52fa34",
         "type": "github"
       },
       "original": {
@@ -756,11 +756,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1723368718,
-        "narHash": "sha256-6RPIPbMS9WvvDc8Tbdnvo/fEjC7dVCcC4/K5yjUSxH8=",
+        "lastModified": 1723540110,
+        "narHash": "sha256-mEsBPb/cKOT5DrrNbSqB6EBarra/etJ4i7h5nqL+s7A=",
         "owner": "abenz1267",
         "repo": "walker",
-        "rev": "14702560d4a9945fc7887997859bde0f59bf5098",
+        "rev": "67cfd756aeebbd92c4a1ca2a856865cbc6763c2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/ffc1f95f6c28e1c6d1e587b51a2147027a3e45ed' (2024-08-08)
  → 'github:nix-community/disko/0d510fe40b56ed74907a021d7e1ffd0042592914' (2024-08-12)
• Updated input 'hyprpaper':
    'github:hyprwm/hyprpaper/f1f7fc60f5ae2609a369964aeb7ddbf6f9277de7' (2024-07-22)
  → 'github:hyprwm/hyprpaper/e32a2c8d246f166f5e454e26984e89028dcd3349' (2024-08-12)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5e0ca22929f3342b19569b21b2f3462f053e497b' (2024-08-09)
  → 'github:nixos/nixpkgs/a58bc8ad779655e790115244571758e8de055e3d' (2024-08-11)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/8ae477955dfd9cbf5fa4eb82a8db8ddbb94e79d9' (2024-08-05)
  → 'github:Mic92/sops-nix/be0eec2d27563590194a9206f551a6f73d52fa34' (2024-08-12)
• Updated input 'walker':
    'github:abenz1267/walker/14702560d4a9945fc7887997859bde0f59bf5098' (2024-08-11)
  → 'github:abenz1267/walker/67cfd756aeebbd92c4a1ca2a856865cbc6763c2f' (2024-08-13)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`ffc1f95f` ➡️ `0d510fe4`](https://github.com/nix-community/disko/compare/ffc1f95f6c28e1c6d1e587b51a2147027a3e45ed...0d510fe40b56ed74907a021d7e1ffd0042592914) <sub>(2024-08-08 to 2024-08-12)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`5e0ca229` ➡️ `a58bc8ad`](https://github.com/nixos/nixpkgs/compare/5e0ca22929f3342b19569b21b2f3462f053e497b...a58bc8ad779655e790115244571758e8de055e3d) <sub>(2024-08-09 to 2024-08-11)</sub>
 - Updated input [`hyprpaper`](https://github.com/hyprwm/hyprpaper): [`f1f7fc60` ➡️ `e32a2c8d`](https://github.com/hyprwm/hyprpaper/compare/f1f7fc60f5ae2609a369964aeb7ddbf6f9277de7...e32a2c8d246f166f5e454e26984e89028dcd3349) <sub>(2024-07-22 to 2024-08-12)</sub>
 - Updated input [`walker`](https://github.com/abenz1267/walker): [`14702560` ➡️ `67cfd756`](https://github.com/abenz1267/walker/compare/14702560d4a9945fc7887997859bde0f59bf5098...67cfd756aeebbd92c4a1ca2a856865cbc6763c2f) <sub>(2024-08-11 to 2024-08-13)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`8ae47795` ➡️ `be0eec2d`](https://github.com/Mic92/sops-nix/compare/8ae477955dfd9cbf5fa4eb82a8db8ddbb94e79d9...be0eec2d27563590194a9206f551a6f73d52fa34) <sub>(2024-08-05 to 2024-08-12)</sub>