### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1722997334,
-        "narHash": "sha256-vE5FcKVQ3E0txJKt5w3vOlfcN1XoTAlxK9PnQ/CJavA=",
+        "lastModified": 1723691425,
+        "narHash": "sha256-F25VvHFMaqr26b7goaVWspXaK6XTRFz8RnILV+9OPkk=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "66f4ea170093b62f319f41cebd2337a51b225c5a",
+        "rev": "552056779a136092eb6358c573d925630172fc30",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723080788,
-        "narHash": "sha256-C5LbM5VMdcolt9zHeLQ0bYMRjUL+N+AL5pK7/tVTdes=",
+        "lastModified": 1723685519,
+        "narHash": "sha256-GkXQIoZmW2zCPp1YFtAYGg/xHNyFH/Mgm79lcs81rq0=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "ffc1f95f6c28e1c6d1e587b51a2147027a3e45ed",
+        "rev": "276a0d055a720691912c6a34abb724e395c8e38a",
         "type": "github"
       },
       "original": {
@@ -327,11 +327,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1721686135,
-        "narHash": "sha256-Hu2r0BX0/98FzNXI5Nmr+Y0C03iymd+TBiCdR8poW+M=",
+        "lastModified": 1723836413,
+        "narHash": "sha256-HIK7XJWQCM0BAnwW5uC7P0e7DAkVTy5jlxQ0NwoSy4M=",
         "owner": "hyprwm",
         "repo": "hyprpaper",
-        "rev": "f1f7fc60f5ae2609a369964aeb7ddbf6f9277de7",
+        "rev": "808d88e5745e775763109e26502e951043349d5f",
         "type": "github"
       },
       "original": {
@@ -541,11 +541,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1723175592,
-        "narHash": "sha256-M0xJ3FbDUc4fRZ84dPGx5VvgFsOzds77KiBMW/mMTnI=",
+        "lastModified": 1723637854,
+        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
+        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722897572,
-        "narHash": "sha256-3m/iyyjCdRBF8xyehf59QlckIcmShyTesymSb+N4Ap4=",
+        "lastModified": 1723501126,
+        "narHash": "sha256-N9IcHgj/p1+2Pvk8P4Zc1bfrMwld5PcosVA0nL6IGdE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8ae477955dfd9cbf5fa4eb82a8db8ddbb94e79d9",
+        "rev": "be0eec2d27563590194a9206f551a6f73d52fa34",
         "type": "github"
       },
       "original": {
@@ -756,11 +756,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1723368718,
-        "narHash": "sha256-6RPIPbMS9WvvDc8Tbdnvo/fEjC7dVCcC4/K5yjUSxH8=",
+        "lastModified": 1723806432,
+        "narHash": "sha256-cVWBpe+quzZweZkklFgw10CN7/KrhvqPvFpzbuLILzw=",
         "owner": "abenz1267",
         "repo": "walker",
-        "rev": "14702560d4a9945fc7887997859bde0f59bf5098",
+        "rev": "33a017280b9b2b3ff55b02941c39ac3d095a9333",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/66f4ea170093b62f319f41cebd2337a51b225c5a' (2024-08-07)
  → 'github:catppuccin/nix/552056779a136092eb6358c573d925630172fc30' (2024-08-15)
• Updated input 'disko':
    'github:nix-community/disko/ffc1f95f6c28e1c6d1e587b51a2147027a3e45ed' (2024-08-08)
  → 'github:nix-community/disko/276a0d055a720691912c6a34abb724e395c8e38a' (2024-08-15)
• Updated input 'hyprpaper':
    'github:hyprwm/hyprpaper/f1f7fc60f5ae2609a369964aeb7ddbf6f9277de7' (2024-07-22)
  → 'github:hyprwm/hyprpaper/808d88e5745e775763109e26502e951043349d5f' (2024-08-16)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5e0ca22929f3342b19569b21b2f3462f053e497b' (2024-08-09)
  → 'github:nixos/nixpkgs/c3aa7b8938b17aebd2deecf7be0636000d62a2b9' (2024-08-14)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/8ae477955dfd9cbf5fa4eb82a8db8ddbb94e79d9' (2024-08-05)
  → 'github:Mic92/sops-nix/be0eec2d27563590194a9206f551a6f73d52fa34' (2024-08-12)
• Updated input 'walker':
    'github:abenz1267/walker/14702560d4a9945fc7887997859bde0f59bf5098' (2024-08-11)
  → 'github:abenz1267/walker/33a017280b9b2b3ff55b02941c39ac3d095a9333' (2024-08-16)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`ffc1f95f` ➡️ `276a0d05`](https://github.com/nix-community/disko/compare/ffc1f95f6c28e1c6d1e587b51a2147027a3e45ed...276a0d055a720691912c6a34abb724e395c8e38a) <sub>(2024-08-08 to 2024-08-15)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`5e0ca229` ➡️ `c3aa7b89`](https://github.com/nixos/nixpkgs/compare/5e0ca22929f3342b19569b21b2f3462f053e497b...c3aa7b8938b17aebd2deecf7be0636000d62a2b9) <sub>(2024-08-09 to 2024-08-14)</sub>
 - Updated input [`hyprpaper`](https://github.com/hyprwm/hyprpaper): [`f1f7fc60` ➡️ `808d88e5`](https://github.com/hyprwm/hyprpaper/compare/f1f7fc60f5ae2609a369964aeb7ddbf6f9277de7...808d88e5745e775763109e26502e951043349d5f) <sub>(2024-07-22 to 2024-08-16)</sub>
 - Updated input [`walker`](https://github.com/abenz1267/walker): [`14702560` ➡️ `33a01728`](https://github.com/abenz1267/walker/compare/14702560d4a9945fc7887997859bde0f59bf5098...33a017280b9b2b3ff55b02941c39ac3d095a9333) <sub>(2024-08-11 to 2024-08-16)</sub>
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`66f4ea17` ➡️ `55205677`](https://github.com/catppuccin/nix/compare/66f4ea170093b62f319f41cebd2337a51b225c5a...552056779a136092eb6358c573d925630172fc30) <sub>(2024-08-07 to 2024-08-15)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`8ae47795` ➡️ `be0eec2d`](https://github.com/Mic92/sops-nix/compare/8ae477955dfd9cbf5fa4eb82a8db8ddbb94e79d9...be0eec2d27563590194a9206f551a6f73d52fa34) <sub>(2024-08-05 to 2024-08-12)</sub>