### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1722997334,
-        "narHash": "sha256-vE5FcKVQ3E0txJKt5w3vOlfcN1XoTAlxK9PnQ/CJavA=",
+        "lastModified": 1724156255,
+        "narHash": "sha256-rpUCeS/QZwQdJmDrvCm0hRi8bFvQNQKAnIMK5ZDBfpM=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "66f4ea170093b62f319f41cebd2337a51b225c5a",
+        "rev": "8886a68edadb1d93c7101337f995ffce4b410ff2",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723080788,
-        "narHash": "sha256-C5LbM5VMdcolt9zHeLQ0bYMRjUL+N+AL5pK7/tVTdes=",
+        "lastModified": 1724163524,
+        "narHash": "sha256-3A06DYw47oSLYMalkWDLzTMHC0MKgm1mNfaca9sqUnI=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "ffc1f95f6c28e1c6d1e587b51a2147027a3e45ed",
+        "rev": "c7b14da22e302e0f9d7aa4df26b61016bcedf738",
         "type": "github"
       },
       "original": {
@@ -274,11 +274,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723399884,
-        "narHash": "sha256-97wn0ihhGqfMb8WcUgzzkM/TuAxce2Gd20A8oiruju4=",
+        "lastModified": 1723986931,
+        "narHash": "sha256-Fy+KEvDQ+Hc8lJAV3t6leXhZJ2ncU5/esxkgt3b8DEY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "086f619dd991a4d355c07837448244029fc2d9ab",
+        "rev": "2598861031b78aadb4da7269df7ca9ddfc3e1671",
         "type": "github"
       },
       "original": {
@@ -327,11 +327,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1721686135,
-        "narHash": "sha256-Hu2r0BX0/98FzNXI5Nmr+Y0C03iymd+TBiCdR8poW+M=",
+        "lastModified": 1723910456,
+        "narHash": "sha256-SSRi7wmanF5VcBUqUHHTeYzIFf1iIUxSDrFxLk/iPR0=",
         "owner": "hyprwm",
         "repo": "hyprpaper",
-        "rev": "f1f7fc60f5ae2609a369964aeb7ddbf6f9277de7",
+        "rev": "91e17e12ff7e862214197cc75cd7d9821eb7d0f7",
         "type": "github"
       },
       "original": {
@@ -421,11 +421,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1723310128,
-        "narHash": "sha256-IiH8jG6PpR4h9TxSGMYh+2/gQiJW9MwehFvheSb5rPc=",
+        "lastModified": 1724067415,
+        "narHash": "sha256-WJBAEFXAtA41RMpK8mvw0cQ62CJkNMBtzcEeNIJV7b0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c54cf53e022b0b3c1d3b8207aa0f9b194c24f0cf",
+        "rev": "b09c46430ffcf18d575acf5c339b38ac4e1db5d2",
         "type": "github"
       },
       "original": {
@@ -541,11 +541,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1723175592,
-        "narHash": "sha256-M0xJ3FbDUc4fRZ84dPGx5VvgFsOzds77KiBMW/mMTnI=",
+        "lastModified": 1723991338,
+        "narHash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
+        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722897572,
-        "narHash": "sha256-3m/iyyjCdRBF8xyehf59QlckIcmShyTesymSb+N4Ap4=",
+        "lastModified": 1723501126,
+        "narHash": "sha256-N9IcHgj/p1+2Pvk8P4Zc1bfrMwld5PcosVA0nL6IGdE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8ae477955dfd9cbf5fa4eb82a8db8ddbb94e79d9",
+        "rev": "be0eec2d27563590194a9206f551a6f73d52fa34",
         "type": "github"
       },
       "original": {
@@ -756,11 +756,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1723368718,
-        "narHash": "sha256-6RPIPbMS9WvvDc8Tbdnvo/fEjC7dVCcC4/K5yjUSxH8=",
+        "lastModified": 1723806432,
+        "narHash": "sha256-cVWBpe+quzZweZkklFgw10CN7/KrhvqPvFpzbuLILzw=",
         "owner": "abenz1267",
         "repo": "walker",
-        "rev": "14702560d4a9945fc7887997859bde0f59bf5098",
+        "rev": "33a017280b9b2b3ff55b02941c39ac3d095a9333",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/66f4ea170093b62f319f41cebd2337a51b225c5a' (2024-08-07)
  → 'github:catppuccin/nix/8886a68edadb1d93c7101337f995ffce4b410ff2' (2024-08-20)
• Updated input 'disko':
    'github:nix-community/disko/ffc1f95f6c28e1c6d1e587b51a2147027a3e45ed' (2024-08-08)
  → 'github:nix-community/disko/c7b14da22e302e0f9d7aa4df26b61016bcedf738' (2024-08-20)
• Updated input 'home-manager':
    'github:nix-community/home-manager/086f619dd991a4d355c07837448244029fc2d9ab' (2024-08-11)
  → 'github:nix-community/home-manager/2598861031b78aadb4da7269df7ca9ddfc3e1671' (2024-08-18)
• Updated input 'hyprpaper':
    'github:hyprwm/hyprpaper/f1f7fc60f5ae2609a369964aeb7ddbf6f9277de7' (2024-07-22)
  → 'github:hyprwm/hyprpaper/91e17e12ff7e862214197cc75cd7d9821eb7d0f7' (2024-08-17)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/c54cf53e022b0b3c1d3b8207aa0f9b194c24f0cf' (2024-08-10)
  → 'github:NixOS/nixos-hardware/b09c46430ffcf18d575acf5c339b38ac4e1db5d2' (2024-08-19)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5e0ca22929f3342b19569b21b2f3462f053e497b' (2024-08-09)
  → 'github:nixos/nixpkgs/8a3354191c0d7144db9756a74755672387b702ba' (2024-08-18)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/8ae477955dfd9cbf5fa4eb82a8db8ddbb94e79d9' (2024-08-05)
  → 'github:Mic92/sops-nix/be0eec2d27563590194a9206f551a6f73d52fa34' (2024-08-12)
• Updated input 'walker':
    'github:abenz1267/walker/14702560d4a9945fc7887997859bde0f59bf5098' (2024-08-11)
  → 'github:abenz1267/walker/33a017280b9b2b3ff55b02941c39ac3d095a9333' (2024-08-16)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`ffc1f95f` ➡️ `c7b14da2`](https://github.com/nix-community/disko/compare/ffc1f95f6c28e1c6d1e587b51a2147027a3e45ed...c7b14da22e302e0f9d7aa4df26b61016bcedf738) <sub>(2024-08-08 to 2024-08-20)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`5e0ca229` ➡️ `8a335419`](https://github.com/nixos/nixpkgs/compare/5e0ca22929f3342b19569b21b2f3462f053e497b...8a3354191c0d7144db9756a74755672387b702ba) <sub>(2024-08-09 to 2024-08-18)</sub>
 - Updated input [`hyprpaper`](https://github.com/hyprwm/hyprpaper): [`f1f7fc60` ➡️ `91e17e12`](https://github.com/hyprwm/hyprpaper/compare/f1f7fc60f5ae2609a369964aeb7ddbf6f9277de7...91e17e12ff7e862214197cc75cd7d9821eb7d0f7) <sub>(2024-07-22 to 2024-08-17)</sub>
 - Updated input [`walker`](https://github.com/abenz1267/walker): [`14702560` ➡️ `33a01728`](https://github.com/abenz1267/walker/compare/14702560d4a9945fc7887997859bde0f59bf5098...33a017280b9b2b3ff55b02941c39ac3d095a9333) <sub>(2024-08-11 to 2024-08-16)</sub>
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`66f4ea17` ➡️ `8886a68e`](https://github.com/catppuccin/nix/compare/66f4ea170093b62f319f41cebd2337a51b225c5a...8886a68edadb1d93c7101337f995ffce4b410ff2) <sub>(2024-08-07 to 2024-08-20)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`8ae47795` ➡️ `be0eec2d`](https://github.com/Mic92/sops-nix/compare/8ae477955dfd9cbf5fa4eb82a8db8ddbb94e79d9...be0eec2d27563590194a9206f551a6f73d52fa34) <sub>(2024-08-05 to 2024-08-12)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`086f619d` ➡️ `25988610`](https://github.com/nix-community/home-manager/compare/086f619dd991a4d355c07837448244029fc2d9ab...2598861031b78aadb4da7269df7ca9ddfc3e1671) <sub>(2024-08-11 to 2024-08-18)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`c54cf53e` ➡️ `b09c4643`](https://github.com/NixOS/nixos-hardware/compare/c54cf53e022b0b3c1d3b8207aa0f9b194c24f0cf...b09c46430ffcf18d575acf5c339b38ac4e1db5d2) <sub>(2024-08-10 to 2024-08-19)</sub>