### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1724156255,
-        "narHash": "sha256-rpUCeS/QZwQdJmDrvCm0hRi8bFvQNQKAnIMK5ZDBfpM=",
+        "lastModified": 1724469296,
+        "narHash": "sha256-p3R4LUNk6gC+fTKRUm9ByXaoRIocnQMwVuJSIxECQ8o=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "8886a68edadb1d93c7101337f995ffce4b410ff2",
+        "rev": "874e668ddaf3687e8d38ccd0188a641ffefe1cfb",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724163524,
-        "narHash": "sha256-3A06DYw47oSLYMalkWDLzTMHC0MKgm1mNfaca9sqUnI=",
+        "lastModified": 1724895876,
+        "narHash": "sha256-GSqAwa00+vRuHbq9O/yRv7Ov7W/pcMLis3HmeHv8a+Q=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "c7b14da22e302e0f9d7aa4df26b61016bcedf738",
+        "rev": "511388d837178979de66d14ca4a2ebd5f7991cd3",
         "type": "github"
       },
       "original": {
@@ -274,11 +274,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723986931,
-        "narHash": "sha256-Fy+KEvDQ+Hc8lJAV3t6leXhZJ2ncU5/esxkgt3b8DEY=",
+        "lastModified": 1724435763,
+        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2598861031b78aadb4da7269df7ca9ddfc3e1671",
+        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
         "type": "github"
       },
       "original": {
@@ -421,11 +421,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1724067415,
-        "narHash": "sha256-WJBAEFXAtA41RMpK8mvw0cQ62CJkNMBtzcEeNIJV7b0=",
+        "lastModified": 1724878143,
+        "narHash": "sha256-UjpKo92iZ25M05kgSOw/Ti6VZwpgdlOa73zHj8OcaDk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b09c46430ffcf18d575acf5c339b38ac4e1db5d2",
+        "rev": "95c3dfe6ef2e96ddc1ccdd7194e3cda02ca9a8ef",
         "type": "github"
       },
       "original": {
@@ -541,11 +541,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1723991338,
-        "narHash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis=",
+        "lastModified": 1724819573,
+        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
+        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
         "type": "github"
       },
       "original": {
@@ -756,11 +756,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1723806432,
-        "narHash": "sha256-cVWBpe+quzZweZkklFgw10CN7/KrhvqPvFpzbuLILzw=",
+        "lastModified": 1724741320,
+        "narHash": "sha256-UJxLVnKfMLPkzec3XwNHcHE1x5kPFMoyqed0VNgFJ4w=",
         "owner": "abenz1267",
         "repo": "walker",
-        "rev": "33a017280b9b2b3ff55b02941c39ac3d095a9333",
+        "rev": "c73beb081a4e9cb699708f366271e3d550fd3f4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/8886a68edadb1d93c7101337f995ffce4b410ff2' (2024-08-20)
  → 'github:catppuccin/nix/874e668ddaf3687e8d38ccd0188a641ffefe1cfb' (2024-08-24)
• Updated input 'disko':
    'github:nix-community/disko/c7b14da22e302e0f9d7aa4df26b61016bcedf738' (2024-08-20)
  → 'github:nix-community/disko/511388d837178979de66d14ca4a2ebd5f7991cd3' (2024-08-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/2598861031b78aadb4da7269df7ca9ddfc3e1671' (2024-08-18)
  → 'github:nix-community/home-manager/c2cd2a52e02f1dfa1c88f95abeb89298d46023be' (2024-08-23)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/b09c46430ffcf18d575acf5c339b38ac4e1db5d2' (2024-08-19)
  → 'github:NixOS/nixos-hardware/95c3dfe6ef2e96ddc1ccdd7194e3cda02ca9a8ef' (2024-08-28)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/8a3354191c0d7144db9756a74755672387b702ba' (2024-08-18)
  → 'github:nixos/nixpkgs/71e91c409d1e654808b2621f28a327acfdad8dc2' (2024-08-28)
• Updated input 'walker':
    'github:abenz1267/walker/33a017280b9b2b3ff55b02941c39ac3d095a9333' (2024-08-16)
  → 'github:abenz1267/walker/c73beb081a4e9cb699708f366271e3d550fd3f4f' (2024-08-27)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`c7b14da2` ➡️ `511388d8`](https://github.com/nix-community/disko/compare/c7b14da22e302e0f9d7aa4df26b61016bcedf738...511388d837178979de66d14ca4a2ebd5f7991cd3) <sub>(2024-08-20 to 2024-08-29)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`8a335419` ➡️ `71e91c40`](https://github.com/nixos/nixpkgs/compare/8a3354191c0d7144db9756a74755672387b702ba...71e91c409d1e654808b2621f28a327acfdad8dc2) <sub>(2024-08-18 to 2024-08-28)</sub>
 - Updated input [`walker`](https://github.com/abenz1267/walker): [`33a01728` ➡️ `c73beb08`](https://github.com/abenz1267/walker/compare/33a017280b9b2b3ff55b02941c39ac3d095a9333...c73beb081a4e9cb699708f366271e3d550fd3f4f) <sub>(2024-08-16 to 2024-08-27)</sub>
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`8886a68e` ➡️ `874e668d`](https://github.com/catppuccin/nix/compare/8886a68edadb1d93c7101337f995ffce4b410ff2...874e668ddaf3687e8d38ccd0188a641ffefe1cfb) <sub>(2024-08-20 to 2024-08-24)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`25988610` ➡️ `c2cd2a52`](https://github.com/nix-community/home-manager/compare/2598861031b78aadb4da7269df7ca9ddfc3e1671...c2cd2a52e02f1dfa1c88f95abeb89298d46023be) <sub>(2024-08-18 to 2024-08-23)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`b09c4643` ➡️ `95c3dfe6`](https://github.com/NixOS/nixos-hardware/compare/b09c46430ffcf18d575acf5c339b38ac4e1db5d2...95c3dfe6ef2e96ddc1ccdd7194e3cda02ca9a8ef) <sub>(2024-08-19 to 2024-08-28)</sub>