### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -11,11 +11,11 @@
         "sf-pro": "sf-pro"
       },
       "locked": {
-        "lastModified": 1719591391,
-        "narHash": "sha256-sVTFewitXIYe5vBihbCFQGdBPdnT26kES1T05umBBnE=",
+        "lastModified": 1727471833,
+        "narHash": "sha256-l/kJYkgMZc4swVnETpUEU2W/CXIDf0fLTMWdtySbl0k=",
         "owner": "Lyndeno",
         "repo": "apple-fonts.nix",
-        "rev": "0e21619dad5b0d9ca2e050155e32448380547b06",
+        "rev": "c32ac2c2d73acb0d9ffad7ef94887f4b738ca8a4",
         "type": "github"
       },
       "original": {
@@ -171,11 +171,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -379,11 +379,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1727040444,
-        "narHash": "sha256-19FNN5QT9Z11ZUMfftRplyNN+2PgcHKb3oq8KMW/hDA=",
+        "lastModified": 1727437159,
+        "narHash": "sha256-v4qLwEw5OmprgQZTT7KZMNU7JjXJzRypw8+Cw6++fWk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d0cb432a9d28218df11cbd77d984a2a46caeb5ac",
+        "rev": "d830ad47cc992b4a46b342bbc79694cbd0e980b2",
         "type": "github"
       },
       "original": {
@@ -438,11 +438,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717786204,
-        "narHash": "sha256-4q0s6m0GUcN7q+Y2DqD27iLvbcd1G50T2lv08kKxkSI=",
+        "lastModified": 1727348695,
+        "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "051f920625ab5aabe37c920346e3e69d7d34400e",
+        "rev": "1925c603f17fc89f4c8f6bf6f631a802ad85d784",
         "type": "github"
       },
       "original": {
@@ -483,11 +483,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1727122398,
-        "narHash": "sha256-o8VBeCWHBxGd4kVMceIayf5GApqTavJbTa44Xcg5Rrk=",
+        "lastModified": 1727348695,
+        "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "30439d93eb8b19861ccbe3e581abf97bdc91b093",
+        "rev": "1925c603f17fc89f4c8f6bf6f631a802ad85d784",
         "type": "github"
       },
       "original": {
@@ -516,7 +516,7 @@
     "ny": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-FkV8Z2fdUTwvcKeltFJVCisvAarcdnmlj/33exdyxnQ=",
+        "narHash": "sha256-3257NAH4qlan2YHVLpNRy7x8IJqR2pal3OzFo/ykqXs=",
         "type": "file",
         "url": "https://devimages-cdn.apple.com/design/resources/download/NY.dmg"
       },
@@ -543,7 +543,7 @@
     "sf-arabic": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-u+Q2Hd+JCiKhIQtbQqawg1lIEgGhjmdGye2cNdWlBG0=",
+        "narHash": "sha256-/0gjRimqvZyE60xYxxPdlU+7Q2LJnnvtbmwOP0YmS9U=",
         "type": "file",
         "url": "https://devimages-cdn.apple.com/design/resources/download/SF-Arabic.dmg"
       },
@@ -596,11 +596,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1726524647,
-        "narHash": "sha256-qis6BtOOBBEAfUl7FMHqqTwRLB61OL5OFzIsOmRz2J4=",
+        "lastModified": 1727423009,
+        "narHash": "sha256-+4B/dQm2EnORIk0k2wV3aHGaE0WXTBjColXjj7qWh10=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "e2d404a7ea599a013189aa42947f66cede0645c8",
+        "rev": "127a96f49ddc377be6ba76964411bab11ae27803",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'apple-fonts':
    'github:Lyndeno/apple-fonts.nix/0e21619dad5b0d9ca2e050155e32448380547b06' (2024-06-28)
  → 'github:Lyndeno/apple-fonts.nix/c32ac2c2d73acb0d9ffad7ef94887f4b738ca8a4' (2024-09-27)
• Updated input 'apple-fonts/flake-utils':
    'github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a' (2024-03-11)
  → 'github:numtide/flake-utils/c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a' (2024-09-17)
• Updated input 'apple-fonts/nixpkgs':
    'github:nixos/nixpkgs/051f920625ab5aabe37c920346e3e69d7d34400e' (2024-06-07)
  → 'github:nixos/nixpkgs/1925c603f17fc89f4c8f6bf6f631a802ad85d784' (2024-09-26)
• Updated input 'apple-fonts/ny':
    'https://devimages-cdn.apple.com/design/resources/download/NY.dmg?narHash=sha256-FkV8Z2fdUTwvcKeltFJVCisvAarcdnmlj/33exdyxnQ%3D'
  → 'https://devimages-cdn.apple.com/design/resources/download/NY.dmg?narHash=sha256-3257NAH4qlan2YHVLpNRy7x8IJqR2pal3OzFo/ykqXs%3D'
• Updated input 'apple-fonts/sf-arabic':
    'https://devimages-cdn.apple.com/design/resources/download/SF-Arabic.dmg?narHash=sha256-u%2BQ2Hd%2BJCiKhIQtbQqawg1lIEgGhjmdGye2cNdWlBG0%3D'
  → 'https://devimages-cdn.apple.com/design/resources/download/SF-Arabic.dmg?narHash=sha256-/0gjRimqvZyE60xYxxPdlU%2B7Q2LJnnvtbmwOP0YmS9U%3D'
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/d0cb432a9d28218df11cbd77d984a2a46caeb5ac' (2024-09-22)
  → 'github:NixOS/nixos-hardware/d830ad47cc992b4a46b342bbc79694cbd0e980b2' (2024-09-27)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/30439d93eb8b19861ccbe3e581abf97bdc91b093' (2024-09-23)
  → 'github:nixos/nixpkgs/1925c603f17fc89f4c8f6bf6f631a802ad85d784' (2024-09-26)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/e2d404a7ea599a013189aa42947f66cede0645c8' (2024-09-16)
  → 'github:Mic92/sops-nix/127a96f49ddc377be6ba76964411bab11ae27803' (2024-09-27)

```

</p></details>

 - Updated input [`apple-fonts/nixpkgs`](https://github.com/nixos/nixpkgs): [`051f9206` ➡️ `1925c603`](https://github.com/nixos/nixpkgs/compare/051f920625ab5aabe37c920346e3e69d7d34400e...1925c603f17fc89f4c8f6bf6f631a802ad85d784) <sub>(2024-06-07 to 2024-09-26)</sub>
 - Updated input `apple-fonts/ny`: `` ➡️ `` <sub>( to )</sub>
 - Updated input [`apple-fonts`](https://github.com/Lyndeno/apple-fonts.nix): [`0e21619d` ➡️ `c32ac2c2`](https://github.com/Lyndeno/apple-fonts.nix/compare/0e21619dad5b0d9ca2e050155e32448380547b06...c32ac2c2d73acb0d9ffad7ef94887f4b738ca8a4) <sub>(2024-06-28 to 2024-09-27)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`30439d93` ➡️ `1925c603`](https://github.com/nixos/nixpkgs/compare/30439d93eb8b19861ccbe3e581abf97bdc91b093...1925c603f17fc89f4c8f6bf6f631a802ad85d784) <sub>(2024-09-23 to 2024-09-26)</sub>
 - Updated input [`apple-fonts/flake-utils`](https://github.com/numtide/flake-utils): [`b1d9ab70` ➡️ `c1dfcf08`](https://github.com/numtide/flake-utils/compare/b1d9ab70662946ef0850d488da1c9019f3a9752a...c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a) <sub>(2024-03-11 to 2024-09-17)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`e2d404a7` ➡️ `127a96f4`](https://github.com/Mic92/sops-nix/compare/e2d404a7ea599a013189aa42947f66cede0645c8...127a96f49ddc377be6ba76964411bab11ae27803) <sub>(2024-09-16 to 2024-09-27)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`d0cb432a` ➡️ `d830ad47`](https://github.com/NixOS/nixos-hardware/compare/d0cb432a9d28218df11cbd77d984a2a46caeb5ac...d830ad47cc992b4a46b342bbc79694cbd0e980b2) <sub>(2024-09-22 to 2024-09-27)</sub>
 - Updated input `apple-fonts/sf-arabic`: `` ➡️ `` <sub>( to )</sub>