### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1727910534,
-        "narHash": "sha256-IjdGPDnBNk3r5h02kiPTKUOfn+UiKNWlhy/ozC0NgyQ=",
+        "lastModified": 1728407414,
+        "narHash": "sha256-B8LaxUP93eh+it8RW1pGq4SsU2kj7f0ipzFuhBvpON8=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "bad96d3fabf8d2e8f0bf0c2cb899a9fccf01ea03",
+        "rev": "96cf8b4a05fb23a53c027621b1147b5cf9e5439f",
         "type": "github"
       },
       "original": {
@@ -110,11 +110,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728109432,
-        "narHash": "sha256-wmbErh8FG7dRKOtMMpHUqDtFjeqt9Zjx4zssSeTalwU=",
+        "lastModified": 1728687662,
+        "narHash": "sha256-D9TChzb00eTG1YWBx8eN2s6lJJnBjB5Y7RpxkAzGvyQ=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "48ebb577855fb2398653f033b3b2208a9249203d",
+        "rev": "bdbdb725d632863bdedb80baabf21327614dd237",
         "type": "github"
       },
       "original": {
@@ -212,11 +212,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728041527,
-        "narHash": "sha256-03liqiJtk9UP7YQHW4r8MduKCK242FQzud8iWvvlK+o=",
+        "lastModified": 1728685293,
+        "narHash": "sha256-1WowL96pksT/XCi+ZXHgqiQ9NiU5oxWuNIQYWqOoEYc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e",
+        "rev": "2b13611eaed8326789f76f70d21d06fbb14e3e47",
         "type": "github"
       },
       "original": {
@@ -335,11 +335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721133318,
-        "narHash": "sha256-lDPT3XRH14Z5WTdtWhgiYa8FjQHeYFCY7Dpy9xU8vyM=",
+        "lastModified": 1728251980,
+        "narHash": "sha256-UfOpuc/gW42i95MztUj6mDbNCdtK/pbO0Lgvzv+b448=",
         "owner": "niksingh710",
         "repo": "minimal-tmux-status",
-        "rev": "86de1697b6b0522ebd36b5fe83c5fd9b7e30f15f",
+        "rev": "3bcfbc350ce4c652c7d4b0f7aeb77400962f4bbc",
         "type": "github"
       },
       "original": {
@@ -379,11 +379,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1728056216,
-        "narHash": "sha256-IrO06gFUDTrTlIP3Sz+mRB6WUoO2YsgMtOD3zi0VEt0=",
+        "lastModified": 1728269138,
+        "narHash": "sha256-oKxDImsOvgUZMY4NwXVyUc/c1HiU2qInX+b5BU0yXls=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b7ca02c7565fbf6d27ff20dd6dbd49c5b82eef28",
+        "rev": "ecfcd787f373f43307d764762e139a7cdeb9c22b",
         "type": "github"
       },
       "original": {
@@ -454,11 +454,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1725762081,
-        "narHash": "sha256-vNv+aJUW5/YurRy1ocfvs4q/48yVESwlC/yHzjkZSP8=",
+        "lastModified": 1728156290,
+        "narHash": "sha256-uogSvuAp+1BYtdu6UWuObjHqSbBohpyARXDWqgI12Ss=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dc454045f5b5d814e5862a6d057e7bb5c29edc05",
+        "rev": "17ae88b569bb15590549ff478bab6494dde4a907",
         "type": "github"
       },
       "original": {
@@ -484,11 +484,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1728018373,
-        "narHash": "sha256-NOiTvBbRLIOe5F6RbHaAh6++BNjsb149fGZd1T4+KBg=",
+        "lastModified": 1728492678,
+        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bc947f541ae55e999ffdb4013441347d83b00feb",
+        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
         "type": "github"
       },
       "original": {
@@ -597,11 +597,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727734513,
-        "narHash": "sha256-i47LQwoGCVQq4upV2YHV0OudkauHNuFsv306ualB/Sw=",
+        "lastModified": 1728345710,
+        "narHash": "sha256-lpunY1+bf90ts+sA2/FgxVNIegPDKCpEoWwOPu4ITTQ=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "3198a242e547939c5e659353551b0668ec150268",
+        "rev": "06535d0e3d0201e6a8080dd32dbfde339b94f01b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/bad96d3fabf8d2e8f0bf0c2cb899a9fccf01ea03' (2024-10-02)
  → 'github:catppuccin/nix/96cf8b4a05fb23a53c027621b1147b5cf9e5439f' (2024-10-08)
• Updated input 'disko':
    'github:nix-community/disko/48ebb577855fb2398653f033b3b2208a9249203d' (2024-10-05)
  → 'github:nix-community/disko/bdbdb725d632863bdedb80baabf21327614dd237' (2024-10-11)
• Updated input 'home-manager':
    'github:nix-community/home-manager/509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e' (2024-10-04)
  → 'github:nix-community/home-manager/2b13611eaed8326789f76f70d21d06fbb14e3e47' (2024-10-11)
• Updated input 'minimal-tmux':
    'github:niksingh710/minimal-tmux-status/86de1697b6b0522ebd36b5fe83c5fd9b7e30f15f' (2024-07-16)
  → 'github:niksingh710/minimal-tmux-status/3bcfbc350ce4c652c7d4b0f7aeb77400962f4bbc' (2024-10-06)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/b7ca02c7565fbf6d27ff20dd6dbd49c5b82eef28' (2024-10-04)
  → 'github:NixOS/nixos-hardware/ecfcd787f373f43307d764762e139a7cdeb9c22b' (2024-10-07)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/bc947f541ae55e999ffdb4013441347d83b00feb' (2024-10-04)
  → 'github:nixos/nixpkgs/5633bcff0c6162b9e4b5f1264264611e950c8ec7' (2024-10-09)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/3198a242e547939c5e659353551b0668ec150268' (2024-09-30)
  → 'github:Mic92/sops-nix/06535d0e3d0201e6a8080dd32dbfde339b94f01b' (2024-10-08)
• Updated input 'sops-nix/nixpkgs-stable':
    'github:NixOS/nixpkgs/dc454045f5b5d814e5862a6d057e7bb5c29edc05' (2024-09-08)
  → 'github:NixOS/nixpkgs/17ae88b569bb15590549ff478bab6494dde4a907' (2024-10-05)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`48ebb577` ➡️ `bdbdb725`](https://github.com/nix-community/disko/compare/48ebb577855fb2398653f033b3b2208a9249203d...bdbdb725d632863bdedb80baabf21327614dd237) <sub>(2024-10-05 to 2024-10-11)</sub>
 - Updated input [`sops-nix/nixpkgs-stable`](https://github.com/NixOS/nixpkgs): [`dc454045` ➡️ `17ae88b5`](https://github.com/NixOS/nixpkgs/compare/dc454045f5b5d814e5862a6d057e7bb5c29edc05...17ae88b569bb15590549ff478bab6494dde4a907) <sub>(2024-09-08 to 2024-10-05)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`bc947f54` ➡️ `5633bcff`](https://github.com/nixos/nixpkgs/compare/bc947f541ae55e999ffdb4013441347d83b00feb...5633bcff0c6162b9e4b5f1264264611e950c8ec7) <sub>(2024-10-04 to 2024-10-09)</sub>
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`bad96d3f` ➡️ `96cf8b4a`](https://github.com/catppuccin/nix/compare/bad96d3fabf8d2e8f0bf0c2cb899a9fccf01ea03...96cf8b4a05fb23a53c027621b1147b5cf9e5439f) <sub>(2024-10-02 to 2024-10-08)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`3198a242` ➡️ `06535d0e`](https://github.com/Mic92/sops-nix/compare/3198a242e547939c5e659353551b0668ec150268...06535d0e3d0201e6a8080dd32dbfde339b94f01b) <sub>(2024-09-30 to 2024-10-08)</sub>
 - Updated input [`minimal-tmux`](https://github.com/niksingh710/minimal-tmux-status): [`86de1697` ➡️ `3bcfbc35`](https://github.com/niksingh710/minimal-tmux-status/compare/86de1697b6b0522ebd36b5fe83c5fd9b7e30f15f...3bcfbc350ce4c652c7d4b0f7aeb77400962f4bbc) <sub>(2024-07-16 to 2024-10-06)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`509dbf8d` ➡️ `2b13611e`](https://github.com/nix-community/home-manager/compare/509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e...2b13611eaed8326789f76f70d21d06fbb14e3e47) <sub>(2024-10-04 to 2024-10-11)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`b7ca02c7` ➡️ `ecfcd787`](https://github.com/NixOS/nixos-hardware/compare/b7ca02c7565fbf6d27ff20dd6dbd49c5b82eef28...ecfcd787f373f43307d764762e139a7cdeb9c22b) <sub>(2024-10-04 to 2024-10-07)</sub>