### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729588208,
-        "narHash": "sha256-PNONdMd+sG7JWzNIDerX7oVZXL8FTVlSAZ1BmUo2HjE=",
+        "lastModified": 1729712798,
+        "narHash": "sha256-a+Aakkb+amHw4biOZ0iMo8xYl37uUL48YEXIC5PYJ/8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "4be2aadf13b67ffbb993deb73adff77c46b728fc",
+        "rev": "09a776702b004fdf9c41a024e1299d575ee18a7d",
         "type": "github"
       },
       "original": {
@@ -212,11 +212,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729551526,
-        "narHash": "sha256-7LAGY32Xl14OVQp3y6M43/0AtHYYvV6pdyBcp3eoz0s=",
+        "lastModified": 1729894599,
+        "narHash": "sha256-nL9nzNE5/re/P+zOv7NX6bRm5e+DeS1HIufQUJ01w20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5ec753a1fc4454df9285d8b3ec0809234defb975",
+        "rev": "93435d27d250fa986bfec6b2ff263161ff8288cb",
         "type": "github"
       },
       "original": {
@@ -265,11 +265,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1725200438,
-        "narHash": "sha256-3Cqu8jz19YyWqhneac6QFfadlyxZ4s3saSLmmpYMOe4=",
+        "lastModified": 1729890887,
+        "narHash": "sha256-Vg98Dm6MaglEUNNTRgLF2Lxy02FrU5ntnlwsMkBSTKg=",
         "owner": "hyprwm",
         "repo": "hyprpaper",
-        "rev": "1c18ad65032adb891b341292a1edf9e13adf4751",
+        "rev": "3f8cc92109209364e9d39789b3631e9ac109987a",
         "type": "github"
       },
       "original": {
@@ -335,11 +335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729322955,
-        "narHash": "sha256-0PROCM7iirKywY4SYjVkAgUio+NxjsCM+4TdiXjcuaw=",
+        "lastModified": 1729668235,
+        "narHash": "sha256-XlI4EN8HkgWqv5M83BBIY0TA78wgDPKvXxP7eFgVBqE=",
         "owner": "niksingh710",
         "repo": "minimal-tmux-status",
-        "rev": "672b230313fa238e569c672eb30a0677982156bf",
+        "rev": "40108961c064241455c180b2533f64f3b196eeca",
         "type": "github"
       },
       "original": {
@@ -379,11 +379,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1729624485,
-        "narHash": "sha256-iEffyT68tEU5kHQuyP05QRH+JhWNNLAwHfgZAzXFS7o=",
+        "lastModified": 1729742320,
+        "narHash": "sha256-u3Of8xRkN//me8PU+RucKA59/6RNy4B2jcGAF36P4jI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "22e8de2729f40d29a445c8baeaf22740b8b25daf",
+        "rev": "e8a2f6d5513fe7b7d15701b2d05404ffdc3b6dda",
         "type": "github"
       },
       "original": {
@@ -484,11 +484,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1729413321,
-        "narHash": "sha256-I4tuhRpZFa6Fu6dcH9Dlo5LlH17peT79vx1y1SpeKt0=",
+        "lastModified": 1729665710,
+        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1997e4aa514312c1af7e2bda7fad1644e778ff26",
+        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
         "type": "github"
       },
       "original": {
@@ -614,11 +614,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729587807,
-        "narHash": "sha256-YOc4033a/j1TbdLfkaSOSX2SrvlmuM+enIFoveNTCz4=",
+        "lastModified": 1729775275,
+        "narHash": "sha256-J2vtHq9sw1wWm0aTMXpEEAzsVCUMZDTEe5kiBYccpLE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "26642e8f193f547e72d38cd4c0c4e45b49236d27",
+        "rev": "78a0e634fc8981d6b564f08b6715c69a755c4c7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/4be2aadf13b67ffbb993deb73adff77c46b728fc' (2024-10-22)
  → 'github:nix-community/disko/09a776702b004fdf9c41a024e1299d575ee18a7d' (2024-10-23)
• Updated input 'home-manager':
    'github:nix-community/home-manager/5ec753a1fc4454df9285d8b3ec0809234defb975' (2024-10-21)
  → 'github:nix-community/home-manager/93435d27d250fa986bfec6b2ff263161ff8288cb' (2024-10-25)
• Updated input 'hyprpaper':
    'github:hyprwm/hyprpaper/1c18ad65032adb891b341292a1edf9e13adf4751' (2024-09-01)
  → 'github:hyprwm/hyprpaper/3f8cc92109209364e9d39789b3631e9ac109987a' (2024-10-25)
• Updated input 'minimal-tmux':
    'github:niksingh710/minimal-tmux-status/672b230313fa238e569c672eb30a0677982156bf' (2024-10-19)
  → 'github:niksingh710/minimal-tmux-status/40108961c064241455c180b2533f64f3b196eeca' (2024-10-23)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/22e8de2729f40d29a445c8baeaf22740b8b25daf' (2024-10-22)
  → 'github:NixOS/nixos-hardware/e8a2f6d5513fe7b7d15701b2d05404ffdc3b6dda' (2024-10-24)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/1997e4aa514312c1af7e2bda7fad1644e778ff26' (2024-10-20)
  → 'github:nixos/nixpkgs/2768c7d042a37de65bb1b5b3268fc987e534c49d' (2024-10-23)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/26642e8f193f547e72d38cd4c0c4e45b49236d27' (2024-10-22)
  → 'github:Mic92/sops-nix/78a0e634fc8981d6b564f08b6715c69a755c4c7d' (2024-10-24)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`4be2aadf` ➡️ `09a77670`](https://github.com/nix-community/disko/compare/4be2aadf13b67ffbb993deb73adff77c46b728fc...09a776702b004fdf9c41a024e1299d575ee18a7d) <sub>(2024-10-22 to 2024-10-23)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`1997e4aa` ➡️ `2768c7d0`](https://github.com/nixos/nixpkgs/compare/1997e4aa514312c1af7e2bda7fad1644e778ff26...2768c7d042a37de65bb1b5b3268fc987e534c49d) <sub>(2024-10-20 to 2024-10-23)</sub>
 - Updated input [`hyprpaper`](https://github.com/hyprwm/hyprpaper): [`1c18ad65` ➡️ `3f8cc921`](https://github.com/hyprwm/hyprpaper/compare/1c18ad65032adb891b341292a1edf9e13adf4751...3f8cc92109209364e9d39789b3631e9ac109987a) <sub>(2024-09-01 to 2024-10-25)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`26642e8f` ➡️ `78a0e634`](https://github.com/Mic92/sops-nix/compare/26642e8f193f547e72d38cd4c0c4e45b49236d27...78a0e634fc8981d6b564f08b6715c69a755c4c7d) <sub>(2024-10-22 to 2024-10-24)</sub>
 - Updated input [`minimal-tmux`](https://github.com/niksingh710/minimal-tmux-status): [`672b2303` ➡️ `40108961`](https://github.com/niksingh710/minimal-tmux-status/compare/672b230313fa238e569c672eb30a0677982156bf...40108961c064241455c180b2533f64f3b196eeca) <sub>(2024-10-19 to 2024-10-23)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`5ec753a1` ➡️ `93435d27`](https://github.com/nix-community/home-manager/compare/5ec753a1fc4454df9285d8b3ec0809234defb975...93435d27d250fa986bfec6b2ff263161ff8288cb) <sub>(2024-10-21 to 2024-10-25)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`22e8de27` ➡️ `e8a2f6d5`](https://github.com/NixOS/nixos-hardware/compare/22e8de2729f40d29a445c8baeaf22740b8b25daf...e8a2f6d5513fe7b7d15701b2d05404ffdc3b6dda) <sub>(2024-10-22 to 2024-10-24)</sub>