### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731274291,
-        "narHash": "sha256-cZ0QMpv5p2a6WEE+o9uu0a4ma6RzQDOQTbm7PbixWz8=",
+        "lastModified": 1731549112,
+        "narHash": "sha256-c9I3i1CwZ10SoM5npQQVnfwgvB86jAS3lT4ZqkRoSOI=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "486250f404f4a4f4f33f8f669d83ca5f6e6b7dfc",
+        "rev": "5fd852c4155a689098095406500d0ae3d04654a8",
         "type": "github"
       },
       "original": {
@@ -212,11 +212,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731235328,
-        "narHash": "sha256-NjavpgE9/bMe/ABvZpyHIUeYF1mqR5lhaep3wB79ucs=",
+        "lastModified": 1731604581,
+        "narHash": "sha256-Qq2YZZaDTB3FZLWU/Hgh1uuWlUBl3cMLGB99bm7rFUM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "60bb110917844d354f3c18e05450606a435d2d10",
+        "rev": "1d0862ee2d7c6f6cd720d6f32213fa425004be10",
         "type": "github"
       },
       "original": {
@@ -379,11 +379,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730919458,
-        "narHash": "sha256-yMO0T0QJlmT/x4HEyvrCyigGrdYfIXX3e5gWqB64wLg=",
+        "lastModified": 1731403644,
+        "narHash": "sha256-T9V7CTucjRZ4Qc6pUEV/kpgNGzQbHWfGcfK6JJLfUeI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e1cc1f6483393634aee94514186d21a4871e78d7",
+        "rev": "f6581f1c3b137086e42a08a906bdada63045f991",
         "type": "github"
       },
       "original": {
@@ -484,11 +484,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1731139594,
-        "narHash": "sha256-IigrKK3vYRpUu+HEjPL/phrfh7Ox881er1UEsZvw9Q4=",
+        "lastModified": 1731319897,
+        "narHash": "sha256-PbABj4tnbWFMfBp6OcUK5iGy1QY+/Z96ZcLpooIbuEI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "76612b17c0ce71689921ca12d9ffdc9c23ce40b2",
+        "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
         "type": "github"
       },
       "original": {
@@ -614,11 +614,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731213149,
-        "narHash": "sha256-jR8i6nFLmSmm0cIoeRQ8Q4EBARa3oGaAtEER/OMMxus=",
+        "lastModified": 1731364708,
+        "narHash": "sha256-HC0anOL+KmUQ2hdRl0AtunbAckasxrkn4VLmxbW/WaA=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f1675e3b0e1e663a4af49be67ecbc9e749f85eb7",
+        "rev": "4c91d52db103e757fc25b58998b0576ae702d659",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1731061020,
-        "narHash": "sha256-elnF3WG8sga3QLpUAPjyrYSL1pYqiFfDoLFEjbWDQ/A=",
+        "lastModified": 1731564562,
+        "narHash": "sha256-cXS/sSn9b/ni523WvYBAeSNRg0/3C0+nNq/jnVu1G2g=",
         "owner": "abenz1267",
         "repo": "walker",
-        "rev": "585c6f1fdfd8a58c856ec15ae373d86f6159a114",
+        "rev": "34b5a8f570319572308c1006a2a954db3ec9e395",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/486250f404f4a4f4f33f8f669d83ca5f6e6b7dfc' (2024-11-10)
  → 'github:nix-community/disko/5fd852c4155a689098095406500d0ae3d04654a8' (2024-11-14)
• Updated input 'home-manager':
    'github:nix-community/home-manager/60bb110917844d354f3c18e05450606a435d2d10' (2024-11-10)
  → 'github:nix-community/home-manager/1d0862ee2d7c6f6cd720d6f32213fa425004be10' (2024-11-14)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/e1cc1f6483393634aee94514186d21a4871e78d7' (2024-11-06)
  → 'github:NixOS/nixos-hardware/f6581f1c3b137086e42a08a906bdada63045f991' (2024-11-12)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/76612b17c0ce71689921ca12d9ffdc9c23ce40b2' (2024-11-09)
  → 'github:nixos/nixpkgs/dc460ec76cbff0e66e269457d7b728432263166c' (2024-11-11)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/f1675e3b0e1e663a4af49be67ecbc9e749f85eb7' (2024-11-10)
  → 'github:Mic92/sops-nix/4c91d52db103e757fc25b58998b0576ae702d659' (2024-11-11)
• Updated input 'walker':
    'github:abenz1267/walker/585c6f1fdfd8a58c856ec15ae373d86f6159a114' (2024-11-08)
  → 'github:abenz1267/walker/34b5a8f570319572308c1006a2a954db3ec9e395' (2024-11-14)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`486250f4` ➡️ `5fd852c4`](https://github.com/nix-community/disko/compare/486250f404f4a4f4f33f8f669d83ca5f6e6b7dfc...5fd852c4155a689098095406500d0ae3d04654a8) <sub>(2024-11-10 to 2024-11-14)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`76612b17` ➡️ `dc460ec7`](https://github.com/nixos/nixpkgs/compare/76612b17c0ce71689921ca12d9ffdc9c23ce40b2...dc460ec76cbff0e66e269457d7b728432263166c) <sub>(2024-11-09 to 2024-11-11)</sub>
 - Updated input [`walker`](https://github.com/abenz1267/walker): [`585c6f1f` ➡️ `34b5a8f5`](https://github.com/abenz1267/walker/compare/585c6f1fdfd8a58c856ec15ae373d86f6159a114...34b5a8f570319572308c1006a2a954db3ec9e395) <sub>(2024-11-08 to 2024-11-14)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`f1675e3b` ➡️ `4c91d52d`](https://github.com/Mic92/sops-nix/compare/f1675e3b0e1e663a4af49be67ecbc9e749f85eb7...4c91d52db103e757fc25b58998b0576ae702d659) <sub>(2024-11-10 to 2024-11-11)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`60bb1109` ➡️ `1d0862ee`](https://github.com/nix-community/home-manager/compare/60bb110917844d354f3c18e05450606a435d2d10...1d0862ee2d7c6f6cd720d6f32213fa425004be10) <sub>(2024-11-10 to 2024-11-14)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`e1cc1f64` ➡️ `f6581f1c`](https://github.com/NixOS/nixos-hardware/compare/e1cc1f6483393634aee94514186d21a4871e78d7...f6581f1c3b137086e42a08a906bdada63045f991) <sub>(2024-11-06 to 2024-11-12)</sub>