### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
     },
     "catppuccin": {
       "locked": {
-        "lastModified": 1733001911,
-        "narHash": "sha256-uX/9m0TbdhEzuWA0muM5mI/AaWcLiDLjCCyu5Qr9MRk=",
+        "lastModified": 1734057772,
+        "narHash": "sha256-waF/2Y39JXJ4kG3zawmw1J1GxPHopyoOkJKJhfJ7RBs=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "a817009ebfd2cca7f70a77884e5098d0a8c83f8e",
+        "rev": "20b6328df20ae45752c81311d225fd47cba32483",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733168902,
-        "narHash": "sha256-8dupm9GfK+BowGdQd7EHK5V61nneLfr9xR6sc5vtDi0=",
+        "lastModified": 1734088167,
+        "narHash": "sha256-OIitVU+IstPbX/NWn2jLF+/sT9dVKcO2FKeRAzlyX6c=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "785c1e02c7e465375df971949b8dcbde9ec362e5",
+        "rev": "d32f2d1750d61a476a236526b725ec5a32e16342",
         "type": "github"
       },
       "original": {
@@ -193,11 +193,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733354384,
-        "narHash": "sha256-foZG2PLwumxYZkpXq7ajHDhuQlXaUeKfOpFfQpMviLM=",
+        "lastModified": 1734093295,
+        "narHash": "sha256-hSwgGpcZtdDsk1dnzA0xj5cNaHgN9A99hRF/mxMtwS4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0daaded612b0e6eaed0a63fc9d0778d8f05940fe",
+        "rev": "66c5d8b62818ec4c1edb3e941f55ef78df8141a8",
         "type": "github"
       },
       "original": {
@@ -390,11 +390,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1733217105,
-        "narHash": "sha256-fc6jTzIwCIVWTX50FtW6AZpuukuQWSEbPiyg6ZRGWFY=",
+        "lastModified": 1733861262,
+        "narHash": "sha256-+jjPup/ByS0LEVIrBbt7FnGugJgLeG9oc+ivFASYn2U=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "cceee0a31d2f01bcc98b2fbd591327c06a4ea4f9",
+        "rev": "cf737e2eba82b603f54f71b10cb8fd09d22ce3f5",
         "type": "github"
       },
       "original": {
@@ -479,11 +479,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1733212471,
-        "narHash": "sha256-M1+uCoV5igihRfcUKrr1riygbe73/dzNnzPsmaLCmpo=",
+        "lastModified": 1733940404,
+        "narHash": "sha256-Pj39hSoUA86ZePPF/UXiYHHM7hMIkios8TYG29kQT4g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "55d15ad12a74eb7d4646254e13638ad0c4128776",
+        "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
         "type": "github"
       },
       "original": {
@@ -608,11 +608,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733128155,
-        "narHash": "sha256-m6/qwJAJYcidGMEdLqjKzRIjapK4nUfMq7rDCTmZajc=",
+        "lastModified": 1733965552,
+        "narHash": "sha256-GZ4YtqkfyTjJFVCub5yAFWsHknG1nS/zfk7MuHht4Fs=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c6134b6fff6bda95a1ac872a2a9d5f32e3c37856",
+        "rev": "2d73fc6ac4eba4b9a83d3cb8275096fbb7ab4004",
         "type": "github"
       },
       "original": {
@@ -664,11 +664,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1733377670,
-        "narHash": "sha256-vQzyC0m9bIXucxn657szQTFYDED5Jdq4nizntTlHpPs=",
+        "lastModified": 1734070627,
+        "narHash": "sha256-keKdHp4oMqXehTNflLNVMT1EE1sMXQra/dfKtnZW/H8=",
         "owner": "abenz1267",
         "repo": "walker",
-        "rev": "a254dfc3116ca3b22ba665cb102e528f7727d177",
+        "rev": "1086d8af85489378ec4a279030fcc7450c0b759f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/a817009ebfd2cca7f70a77884e5098d0a8c83f8e' (2024-11-30)
  → 'github:catppuccin/nix/20b6328df20ae45752c81311d225fd47cba32483' (2024-12-13)
• Updated input 'disko':
    'github:nix-community/disko/785c1e02c7e465375df971949b8dcbde9ec362e5' (2024-12-02)
  → 'github:nix-community/disko/d32f2d1750d61a476a236526b725ec5a32e16342' (2024-12-13)
• Updated input 'home-manager':
    'github:nix-community/home-manager/0daaded612b0e6eaed0a63fc9d0778d8f05940fe' (2024-12-04)
  → 'github:nix-community/home-manager/66c5d8b62818ec4c1edb3e941f55ef78df8141a8' (2024-12-13)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/cceee0a31d2f01bcc98b2fbd591327c06a4ea4f9' (2024-12-03)
  → 'github:NixOS/nixos-hardware/cf737e2eba82b603f54f71b10cb8fd09d22ce3f5' (2024-12-10)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/55d15ad12a74eb7d4646254e13638ad0c4128776' (2024-12-03)
  → 'github:nixos/nixpkgs/5d67ea6b4b63378b9c13be21e2ec9d1afc921713' (2024-12-11)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/c6134b6fff6bda95a1ac872a2a9d5f32e3c37856' (2024-12-02)
  → 'github:Mic92/sops-nix/2d73fc6ac4eba4b9a83d3cb8275096fbb7ab4004' (2024-12-12)
• Updated input 'walker':
    'github:abenz1267/walker/a254dfc3116ca3b22ba665cb102e528f7727d177' (2024-12-05)
  → 'github:abenz1267/walker/1086d8af85489378ec4a279030fcc7450c0b759f' (2024-12-13)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`785c1e02` ➡️ `d32f2d17`](https://github.com/nix-community/disko/compare/785c1e02c7e465375df971949b8dcbde9ec362e5...d32f2d1750d61a476a236526b725ec5a32e16342) <sub>(2024-12-02 to 2024-12-13)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`55d15ad1` ➡️ `5d67ea6b`](https://github.com/nixos/nixpkgs/compare/55d15ad12a74eb7d4646254e13638ad0c4128776...5d67ea6b4b63378b9c13be21e2ec9d1afc921713) <sub>(2024-12-03 to 2024-12-11)</sub>
 - Updated input [`walker`](https://github.com/abenz1267/walker): [`a254dfc3` ➡️ `1086d8af`](https://github.com/abenz1267/walker/compare/a254dfc3116ca3b22ba665cb102e528f7727d177...1086d8af85489378ec4a279030fcc7450c0b759f) <sub>(2024-12-05 to 2024-12-13)</sub>
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`a817009e` ➡️ `20b6328d`](https://github.com/catppuccin/nix/compare/a817009ebfd2cca7f70a77884e5098d0a8c83f8e...20b6328df20ae45752c81311d225fd47cba32483) <sub>(2024-11-30 to 2024-12-13)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`c6134b6f` ➡️ `2d73fc6a`](https://github.com/Mic92/sops-nix/compare/c6134b6fff6bda95a1ac872a2a9d5f32e3c37856...2d73fc6ac4eba4b9a83d3cb8275096fbb7ab4004) <sub>(2024-12-02 to 2024-12-12)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`0daaded6` ➡️ `66c5d8b6`](https://github.com/nix-community/home-manager/compare/0daaded612b0e6eaed0a63fc9d0778d8f05940fe...66c5d8b62818ec4c1edb3e941f55ef78df8141a8) <sub>(2024-12-04 to 2024-12-13)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`cceee0a3` ➡️ `cf737e2e`](https://github.com/NixOS/nixos-hardware/compare/cceee0a31d2f01bcc98b2fbd591327c06a4ea4f9...cf737e2eba82b603f54f71b10cb8fd09d22ce3f5) <sub>(2024-12-03 to 2024-12-10)</sub>