### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,18 +46,55 @@
       }
     },
     "catppuccin": {
+      "inputs": {
+        "catppuccin-v1_1": "catppuccin-v1_1",
+        "catppuccin-v1_2": "catppuccin-v1_2",
+        "home-manager": "home-manager_2",
+        "home-manager-stable": "home-manager-stable",
+        "nixpkgs": "nixpkgs_3",
+        "nixpkgs-stable": "nixpkgs-stable",
+        "nuscht-search": "nuscht-search"
+      },
       "locked": {
-        "lastModified": 1734671418,
-        "narHash": "sha256-K2Su5hM1nEIgKJ55TB5W+UfN9zBHUxC0SjWAtjXLEnI=",
+        "lastModified": 1735263930,
+        "narHash": "sha256-vU7SkHINr+NqmZeFLA11plsaUfazKKpdEhI/oTJbK3Q=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "6239449c96569547af621899f44a5ea333cb2576",
+        "rev": "a2e641bc6b17129d81d54019e14c9956784c69c6",
         "type": "github"
       },
       "original": {
         "owner": "catppuccin",
         "repo": "nix",
         "type": "github"
+      }
+    },
+    "catppuccin-v1_1": {
+      "locked": {
+        "lastModified": 1734055249,
+        "narHash": "sha256-pCWJgwo77KD7EJpwynwKrWPZ//dwypHq2TfdzZWqK68=",
+        "rev": "7221d6ca17ac36ed20588e1c3a80177ac5843fa7",
+        "revCount": 326,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/catppuccin/nix/1.1.1/0193bdc0-b045-7eed-bbec-95611a8ecdf5/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/catppuccin/nix/1.1.%2A.tar.gz"
+      }
+    },
+    "catppuccin-v1_2": {
+      "locked": {
+        "lastModified": 1734728407,
+        "narHash": "sha256-Let3uJo4YDyfqbqaw66dpZxhJB2TrDyZWSFd5rpPLJA=",
+        "rev": "23ee86dbf4ed347878115a78971d43025362fab1",
+        "revCount": 341,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/catppuccin/nix/1.2.0/0193e5e0-33b7-7149-a362-bfe56b20f64e/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/catppuccin/nix/1.2.%2A.tar.gz"
       }
     },
     "darwin": {
@@ -109,11 +146,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734343412,
-        "narHash": "sha256-b7G8oFp0Nj01BYUJ6ENC9Qf/HsYAIZvN9k/p0Kg/PFU=",
+        "lastModified": 1735048446,
+        "narHash": "sha256-Tc35Y8H+krA6rZeOIczsaGAtobSSBPqR32AfNTeHDRc=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a08bfe06b39e94eec98dd089a2c1b18af01fef19",
+        "rev": "3a4de9fa3a78ba7b7170dda6bd8b4cdab87c0b21",
         "type": "github"
       },
       "original": {
@@ -165,6 +202,24 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -186,9 +241,32 @@
         "type": "github"
       }
     },
+    "home-manager-stable": {
+      "inputs": {
+        "nixpkgs": [
+          "catppuccin",
+          "nixpkgs-stable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1734366194,
+        "narHash": "sha256-vykpJ1xsdkv0j8WOVXrRFHUAdp9NXHpxdnn1F4pYgSw=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "80b0fdf483c5d1cb75aaad909bd390d48673857f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-24.11",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "home-manager_2": {
       "inputs": {
         "nixpkgs": [
+          "catppuccin",
           "nixpkgs"
         ]
       },
@@ -198,6 +276,26 @@
         "owner": "nix-community",
         "repo": "home-manager",
         "rev": "1395379a7a36e40f2a76e7b9936cc52950baa1be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_3": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1735343815,
+        "narHash": "sha256-p7IJP/97zJda/wwCn1T2LJBz4olF5LjNf4uwhuyvARo=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "b7a7cd5dd1a74a9fe86ed4e016f91c78483b527a",
         "type": "github"
       },
       "original": {
@@ -222,11 +320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733684019,
-        "narHash": "sha256-2kYREgmSmbLsmDpLEq96hxVAU3qz8aCvVhF65yCFZHY=",
+        "lastModified": 1734906236,
+        "narHash": "sha256-vH/ysV2ONGQgYZPtcJKwc8jJivzyVxru2aaOxC20ZOE=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "fb2c0268645a77403af3b8a4ce8fa7ba5917f15d",
+        "rev": "6dea3fba08fd704dd624b6d4b261638fb4003c9c",
         "type": "github"
       },
       "original": {
@@ -251,11 +349,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734174076,
-        "narHash": "sha256-s7FX3ax1KCogPbEa8Cc8RWsYnr6jSkWbIdtYmh4cGrs=",
+        "lastModified": 1734906259,
+        "narHash": "sha256-P79t/7HbACO4/PuJBroGpTptvCWJtXTv+gWsF+sM6MI=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "f7acd5dabba315247497bc9f89da2c5e175aa9a1",
+        "rev": "0404833ea18d543df44df935ebf1b497310eb046",
         "type": "github"
       },
       "original": {
@@ -273,14 +371,14 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1734638308,
-        "narHash": "sha256-WNkBPVZe1XD4WKdh6Yi6aEpcUW7Xsu/d5mKwe7F3yYk=",
+        "lastModified": 1734906298,
+        "narHash": "sha256-L0zaWJi2wS/kgdY1WOM8xJuiXDBDh1TMMKLRcmy5ycs=",
         "owner": "hyprwm",
         "repo": "hyprpaper",
-        "rev": "f15e67850743fb787fb29238ab33e81ca6b8daa0",
+        "rev": "2f305d5f480c12882578e74498301129705a1bb5",
         "type": "github"
       },
       "original": {
@@ -301,11 +399,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733502241,
-        "narHash": "sha256-KAUNC4Dgq8WQjYov5auBw/usaHixhacvb7cRDd0AG/k=",
+        "lastModified": 1734796073,
+        "narHash": "sha256-TnuKsa8OHrSJEmHm3TLGOWbPNA1gRjmZLsRzKrCqOsg=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "104117aed6dd68561be38b50f218190aa47f2cd8",
+        "rev": "c3331116ebd0b71df5ae8c6efe9a7f94148b03bf",
         "type": "github"
       },
       "original": {
@@ -326,16 +424,44 @@
         ]
       },
       "locked": {
-        "lastModified": 1726874836,
-        "narHash": "sha256-VKR0sf0PSNCB0wPHVKSAn41mCNVCnegWmgkrneKDhHM=",
+        "lastModified": 1734793513,
+        "narHash": "sha256-rrrHcXapXJvGFqX+L/Bb0182L25jofAZ0fm1FInvrTQ=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "500c81a9e1a76760371049a8d99e008ea77aa59e",
+        "rev": "4d7367b6eee87397e2dbca2e78078dd0a4ef4c61",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
+        "type": "github"
+      }
+    },
+    "ixx": {
+      "inputs": {
+        "flake-utils": [
+          "catppuccin",
+          "nuscht-search",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "catppuccin",
+          "nuscht-search",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729958008,
+        "narHash": "sha256-EiOq8jF4Z/zQe0QYVc3+qSKxRK//CFHMB84aYrYGwEs=",
+        "owner": "NuschtOS",
+        "repo": "ixx",
+        "rev": "9fd01aad037f345350eab2cd45e1946cc66da4eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NuschtOS",
+        "ref": "v0.0.6",
+        "repo": "ixx",
         "type": "github"
       }
     },
@@ -390,11 +516,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1734352517,
-        "narHash": "sha256-mfv+J/vO4nqmIOlq8Y1rRW8hVsGH3M+I2ESMjhuebDs=",
+        "lastModified": 1734954597,
+        "narHash": "sha256-QIhd8/0x30gEv8XEE1iAnrdMlKuQ0EzthfDR7Hwl+fk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b12e314726a4226298fe82776b4baeaa7bcf3dcd",
+        "rev": "def1d472c832d77885f174089b0d34854b007198",
         "type": "github"
       },
       "original": {
@@ -463,6 +589,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1734600368,
+        "narHash": "sha256-nbG9TijTMcfr+au7ZVbKpAhMJzzE2nQBYmRvSdXUD8g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b47fd6fa00c6afca88b8ee46cfdb00e104f50bca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1727998858,
@@ -481,9 +623,25 @@
       "locked": {
         "lastModified": 1734424634,
         "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
-        "owner": "nixos",
+        "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1735291276,
+        "narHash": "sha256-NYVcA06+blsLG6wpAbSPTCyLvxD/92Hy4vlY9WxFI1M=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
         "type": "github"
       },
       "original": {
@@ -493,7 +651,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1720957393,
         "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
@@ -509,7 +667,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1727348695,
         "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
@@ -522,6 +680,29 @@
         "owner": "nixos",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nuscht-search": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "ixx": "ixx",
+        "nixpkgs": [
+          "catppuccin",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733773348,
+        "narHash": "sha256-Y47y+LesOCkJaLvj+dI/Oa6FAKj/T9sKVKDXLNsViPw=",
+        "owner": "NuschtOS",
+        "repo": "search",
+        "rev": "3051be7f403bff1d1d380e4612f0c70675b44fc9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NuschtOS",
+        "repo": "search",
         "type": "github"
       }
     },
@@ -543,11 +724,11 @@
         "cachix-deploy": "cachix-deploy",
         "catppuccin": "catppuccin",
         "disko": "disko_2",
-        "home-manager": "home-manager_2",
+        "home-manager": "home-manager_3",
         "hyprpaper": "hyprpaper",
         "minimal-tmux": "minimal-tmux",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "sops-nix": "sops-nix",
         "walker": "walker",
         "zen-browser": "zen-browser"
@@ -623,6 +804,21 @@
     },
     "systems": {
       "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
         "lastModified": 1689347949,
         "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
@@ -661,14 +857,14 @@
     "walker": {
       "inputs": {
         "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1734635478,
-        "narHash": "sha256-5+WldWKIb/AY7B4ZHixM56GUQssfverLcuXHrGCED1M=",
+        "lastModified": 1735288946,
+        "narHash": "sha256-kYtYu+wHrqS2uuEaNNET62tdOw+tEkIcbB9BrJ3X35k=",
         "owner": "abenz1267",
         "repo": "walker",
-        "rev": "5444e7b5088c9f40a81addc5d9f01198ba701064",
+        "rev": "ad1623072615fd1d211fd9a9e3ebcc658df7be27",
         "type": "github"
       },
       "original": {
@@ -679,7 +875,7 @@
     },
     "zen-browser": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1727721329,


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/6239449c96569547af621899f44a5ea333cb2576' (2024-12-20)
  → 'github:catppuccin/nix/a2e641bc6b17129d81d54019e14c9956784c69c6' (2024-12-27)
• Added input 'catppuccin/catppuccin-v1_1':
    'https://api.flakehub.com/f/pinned/catppuccin/nix/1.1.1/0193bdc0-b045-7eed-bbec-95611a8ecdf5/source.tar.gz?narHash=sha256-pCWJgwo77KD7EJpwynwKrWPZ//dwypHq2TfdzZWqK68%3D' (2024-12-13)
• Added input 'catppuccin/catppuccin-v1_2':
    'https://api.flakehub.com/f/pinned/catppuccin/nix/1.2.0/0193e5e0-33b7-7149-a362-bfe56b20f64e/source.tar.gz?narHash=sha256-Let3uJo4YDyfqbqaw66dpZxhJB2TrDyZWSFd5rpPLJA%3D' (2024-12-20)
• Added input 'catppuccin/home-manager':
    'github:nix-community/home-manager/1395379a7a36e40f2a76e7b9936cc52950baa1be' (2024-12-19)
• Added input 'catppuccin/home-manager/nixpkgs':
    follows 'catppuccin/nixpkgs'
• Added input 'catppuccin/home-manager-stable':
    'github:nix-community/home-manager/80b0fdf483c5d1cb75aaad909bd390d48673857f' (2024-12-16)
• Added input 'catppuccin/home-manager-stable/nixpkgs':
    follows 'catppuccin/nixpkgs-stable'
• Added input 'catppuccin/nixpkgs':
    'github:NixOS/nixpkgs/d3c42f187194c26d9f0309a8ecc469d6c878ce33' (2024-12-17)
• Added input 'catppuccin/nixpkgs-stable':
    'github:NixOS/nixpkgs/b47fd6fa00c6afca88b8ee46cfdb00e104f50bca' (2024-12-19)
• Added input 'catppuccin/nuscht-search':
    'github:NuschtOS/search/3051be7f403bff1d1d380e4612f0c70675b44fc9' (2024-12-09)
• Added input 'catppuccin/nuscht-search/flake-utils':
    'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' (2024-11-13)
• Added input 'catppuccin/nuscht-search/flake-utils/systems':
    'github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e' (2023-04-09)
• Added input 'catppuccin/nuscht-search/ixx':
    'github:NuschtOS/ixx/9fd01aad037f345350eab2cd45e1946cc66da4eb' (2024-10-26)
• Added input 'catppuccin/nuscht-search/ixx/flake-utils':
    follows 'catppuccin/nuscht-search/flake-utils'
• Added input 'catppuccin/nuscht-search/ixx/nixpkgs':
    follows 'catppuccin/nuscht-search/nixpkgs'
• Added input 'catppuccin/nuscht-search/nixpkgs':
    follows 'catppuccin/nixpkgs'
• Updated input 'disko':
    'github:nix-community/disko/a08bfe06b39e94eec98dd089a2c1b18af01fef19' (2024-12-16)
  → 'github:nix-community/disko/3a4de9fa3a78ba7b7170dda6bd8b4cdab87c0b21' (2024-12-24)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1395379a7a36e40f2a76e7b9936cc52950baa1be' (2024-12-19)
  → 'github:nix-community/home-manager/b7a7cd5dd1a74a9fe86ed4e016f91c78483b527a' (2024-12-27)
• Updated input 'hyprpaper':
    'github:hyprwm/hyprpaper/f15e67850743fb787fb29238ab33e81ca6b8daa0' (2024-12-19)
  → 'github:hyprwm/hyprpaper/2f305d5f480c12882578e74498301129705a1bb5' (2024-12-22)
• Updated input 'hyprpaper/hyprgraphics':
    'github:hyprwm/hyprgraphics/fb2c0268645a77403af3b8a4ce8fa7ba5917f15d' (2024-12-08)
  → 'github:hyprwm/hyprgraphics/6dea3fba08fd704dd624b6d4b261638fb4003c9c' (2024-12-22)
• Updated input 'hyprpaper/hyprlang':
    'github:hyprwm/hyprlang/f7acd5dabba315247497bc9f89da2c5e175aa9a1' (2024-12-14)
  → 'github:hyprwm/hyprlang/0404833ea18d543df44df935ebf1b497310eb046' (2024-12-22)
• Updated input 'hyprpaper/hyprutils':
    'github:hyprwm/hyprutils/104117aed6dd68561be38b50f218190aa47f2cd8' (2024-12-06)
  → 'github:hyprwm/hyprutils/c3331116ebd0b71df5ae8c6efe9a7f94148b03bf' (2024-12-21)
• Updated input 'hyprpaper/hyprwayland-scanner':
    'github:hyprwm/hyprwayland-scanner/500c81a9e1a76760371049a8d99e008ea77aa59e' (2024-09-20)
  → 'github:hyprwm/hyprwayland-scanner/4d7367b6eee87397e2dbca2e78078dd0a4ef4c61' (2024-12-21)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/b12e314726a4226298fe82776b4baeaa7bcf3dcd' (2024-12-16)
  → 'github:NixOS/nixos-hardware/def1d472c832d77885f174089b0d34854b007198' (2024-12-23)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d3c42f187194c26d9f0309a8ecc469d6c878ce33' (2024-12-17)
  → 'github:nixos/nixpkgs/634fd46801442d760e09493a794c4f15db2d0cbb' (2024-12-27)
• Updated input 'walker':
    'github:abenz1267/walker/5444e7b5088c9f40a81addc5d9f01198ba701064' (2024-12-19)
  → 'github:abenz1267/walker/ad1623072615fd1d211fd9a9e3ebcc658df7be27' (2024-12-27)

```

</p></details>

 - Added input `catppuccin/nuscht-search/nixpkgs`: ``
 - Added input `catppuccin/home-manager-stable/nixpkgs`: ``
 - Added input `catppuccin/home-manager/nixpkgs`: ``
 - Added input [`catppuccin/home-manager-stable`](https://github.com/nix-community/home-manager): [github.com/nix-community/home-manager](https://github.com/nix-community/home-manager/tree/80b0fdf483c5d1cb75aaad909bd390d48673857f/)
 - Updated input [`hyprpaper/hyprlang`](https://github.com/hyprwm/hyprlang): [`f7acd5da` ➡️ `0404833e`](https://github.com/hyprwm/hyprlang/compare/f7acd5dabba315247497bc9f89da2c5e175aa9a1...0404833ea18d543df44df935ebf1b497310eb046) <sub>(2024-12-14 to 2024-12-22)</sub>
 - Updated input [`disko`](https://github.com/nix-community/disko): [`a08bfe06` ➡️ `3a4de9fa`](https://github.com/nix-community/disko/compare/a08bfe06b39e94eec98dd089a2c1b18af01fef19...3a4de9fa3a78ba7b7170dda6bd8b4cdab87c0b21) <sub>(2024-12-16 to 2024-12-24)</sub>
 - Added input [`catppuccin/nixpkgs-stable`](https://github.com/NixOS/nixpkgs): [github.com/NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/tree/b47fd6fa00c6afca88b8ee46cfdb00e104f50bca/)
 - Added input [`catppuccin/home-manager`](https://github.com/nix-community/home-manager): [github.com/nix-community/home-manager](https://github.com/nix-community/home-manager/tree/1395379a7a36e40f2a76e7b9936cc52950baa1be/)
 - Updated input [`hyprpaper/hyprwayland-scanner`](https://github.com/hyprwm/hyprwayland-scanner): [`500c81a9` ➡️ `4d7367b6`](https://github.com/hyprwm/hyprwayland-scanner/compare/500c81a9e1a76760371049a8d99e008ea77aa59e...4d7367b6eee87397e2dbca2e78078dd0a4ef4c61) <sub>(2024-09-20 to 2024-12-21)</sub>
 - Updated input [`hyprpaper/hyprgraphics`](https://github.com/hyprwm/hyprgraphics): [`fb2c0268` ➡️ `6dea3fba`](https://github.com/hyprwm/hyprgraphics/compare/fb2c0268645a77403af3b8a4ce8fa7ba5917f15d...6dea3fba08fd704dd624b6d4b261638fb4003c9c) <sub>(2024-12-08 to 2024-12-22)</sub>
 - Added input [`catppuccin/nuscht-search`](https://github.com/NuschtOS/search): [github.com/NuschtOS/search](https://github.com/NuschtOS/search/tree/3051be7f403bff1d1d380e4612f0c70675b44fc9/)
 - Added input `catppuccin/nuscht-search/ixx/nixpkgs`: ``
 - Added input [`catppuccin/nixpkgs`](https://github.com/NixOS/nixpkgs): [github.com/NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/tree/d3c42f187194c26d9f0309a8ecc469d6c878ce33/)
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`d3c42f18` ➡️ `634fd468`](https://github.com/nixos/nixpkgs/compare/d3c42f187194c26d9f0309a8ecc469d6c878ce33...634fd46801442d760e09493a794c4f15db2d0cbb) <sub>(2024-12-17 to 2024-12-27)</sub>
 - Updated input [`hyprpaper/hyprutils`](https://github.com/hyprwm/hyprutils): [`104117ae` ➡️ `c3331116`](https://github.com/hyprwm/hyprutils/compare/104117aed6dd68561be38b50f218190aa47f2cd8...c3331116ebd0b71df5ae8c6efe9a7f94148b03bf) <sub>(2024-12-06 to 2024-12-21)</sub>
 - Updated input [`hyprpaper`](https://github.com/hyprwm/hyprpaper): [`f15e6785` ➡️ `2f305d5f`](https://github.com/hyprwm/hyprpaper/compare/f15e67850743fb787fb29238ab33e81ca6b8daa0...2f305d5f480c12882578e74498301129705a1bb5) <sub>(2024-12-19 to 2024-12-22)</sub>
 - Added input [`catppuccin/nuscht-search/ixx`](https://github.com/NuschtOS/ixx): [github.com/NuschtOS/ixx](https://github.com/NuschtOS/ixx/tree/9fd01aad037f345350eab2cd45e1946cc66da4eb/)
 - Added input [`catppuccin/nuscht-search/flake-utils`](https://github.com/numtide/flake-utils): [github.com/numtide/flake-utils](https://github.com/numtide/flake-utils/tree/11707dc2f618dd54ca8739b309ec4fc024de578b/)
 - Updated input [`walker`](https://github.com/abenz1267/walker): [`5444e7b5` ➡️ `ad162307`](https://github.com/abenz1267/walker/compare/5444e7b5088c9f40a81addc5d9f01198ba701064...ad1623072615fd1d211fd9a9e3ebcc658df7be27) <sub>(2024-12-19 to 2024-12-27)</sub>
 - Added input `catppuccin/catppuccin-v1_1`: `https://api.flakehub.com/f/pinned/catppuccin/nix/1.1.1/0193bdc0-b045-7eed-bbec-95611a8ecdf5/source.tar.gz?narHash=sha256-pCWJgwo77KD7EJpwynwKrWPZ//dwypHq2TfdzZWqK68%3D`
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`6239449c` ➡️ `a2e641bc`](https://github.com/catppuccin/nix/compare/6239449c96569547af621899f44a5ea333cb2576...a2e641bc6b17129d81d54019e14c9956784c69c6) <sub>(2024-12-20 to 2024-12-27)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`1395379a` ➡️ `b7a7cd5d`](https://github.com/nix-community/home-manager/compare/1395379a7a36e40f2a76e7b9936cc52950baa1be...b7a7cd5dd1a74a9fe86ed4e016f91c78483b527a) <sub>(2024-12-19 to 2024-12-27)</sub>
 - Added input `catppuccin/catppuccin-v1_2`: `https://api.flakehub.com/f/pinned/catppuccin/nix/1.2.0/0193e5e0-33b7-7149-a362-bfe56b20f64e/source.tar.gz?narHash=sha256-Let3uJo4YDyfqbqaw66dpZxhJB2TrDyZWSFd5rpPLJA%3D`
 - Added input `catppuccin/nuscht-search/ixx/flake-utils`: ``
 - Added input [`catppuccin/nuscht-search/flake-utils/systems`](https://github.com/nix-systems/default): [github.com/nix-systems/default](https://github.com/nix-systems/default/tree/da67096a3b9bf56a91d16901293e51ba5b49a27e/)
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`b12e3147` ➡️ `def1d472`](https://github.com/NixOS/nixos-hardware/compare/b12e314726a4226298fe82776b4baeaa7bcf3dcd...def1d472c832d77885f174089b0d34854b007198) <sub>(2024-12-16 to 2024-12-23)</sub>