### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1741732420,
-        "narHash": "sha256-szO/TCc+UrjEtxi4K3GyoAv5/DKDkUeRtpTZTJY+zI4=",
+        "lastModified": 1741985801,
+        "narHash": "sha256-EnjiCpEi8p1kFgNUCVPuDUYoOSYBlr7ByMEF8qMGZws=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "a3f70463fb5e3df32d2d52a2705606db03843de2",
+        "rev": "f833a338ff6c091c84e041ee77ce88f8b242ca79",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741791118,
-        "narHash": "sha256-4Y427uj0eql4yRU5rely3EcOlB9q457UDbG9omPtXiA=",
+        "lastModified": 1741955947,
+        "narHash": "sha256-2lbURKclgKqBNm7hVRtWh0A7NrdsibD0EaWhahUVhhY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "18780912345970e5b546b1b085385789b6935a83",
+        "rev": "4e12151c9e014e2449e0beca2c0e9534b96a26b4",
         "type": "github"
       },
       "original": {
@@ -464,11 +464,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1741246872,
-        "narHash": "sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U=",
+        "lastModified": 1741851582,
+        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "10069ef4cf863633f57238f179a0297de84bd8d3",
+        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
         "type": "github"
       },
       "original": {
@@ -480,11 +480,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1741513245,
-        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "lastModified": 1741851582,
+        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
+        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
         "type": "github"
       },
       "original": {
@@ -628,11 +628,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741644481,
-        "narHash": "sha256-E0RrMykMtEv15V3QhpsFutgoSKhL1JBhidn+iZajOyg=",
+        "lastModified": 1741861888,
+        "narHash": "sha256-ynOgXAyToeE1UdLNfrUn/hL7MN0OpIS2BtNdLjpjPf0=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "e653d71e82575a43fe9d228def8eddb73887b866",
+        "rev": "d016ce0365b87d848a57c12ffcfdc71da7a2b55f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/a3f70463fb5e3df32d2d52a2705606db03843de2' (2025-03-11)
  → 'github:catppuccin/nix/f833a338ff6c091c84e041ee77ce88f8b242ca79' (2025-03-14)
• Updated input 'catppuccin/nixpkgs':
    'github:NixOS/nixpkgs/10069ef4cf863633f57238f179a0297de84bd8d3' (2025-03-06)
  → 'github:NixOS/nixpkgs/6607cf789e541e7873d40d3a8f7815ea92204f32' (2025-03-13)
• Updated input 'home-manager':
    'github:nix-community/home-manager/18780912345970e5b546b1b085385789b6935a83' (2025-03-12)
  → 'github:nix-community/home-manager/4e12151c9e014e2449e0beca2c0e9534b96a26b4' (2025-03-14)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e3e32b642a31e6714ec1b712de8c91a3352ce7e1' (2025-03-09)
  → 'github:nixos/nixpkgs/6607cf789e541e7873d40d3a8f7815ea92204f32' (2025-03-13)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/e653d71e82575a43fe9d228def8eddb73887b866' (2025-03-10)
  → 'github:Mic92/sops-nix/d016ce0365b87d848a57c12ffcfdc71da7a2b55f' (2025-03-13)

```

</p></details>

 - Updated input [`catppuccin/nixpkgs`](https://github.com/NixOS/nixpkgs): [`10069ef4` ➡️ `6607cf78`](https://github.com/NixOS/nixpkgs/compare/10069ef4cf863633f57238f179a0297de84bd8d3...6607cf789e541e7873d40d3a8f7815ea92204f32) <sub>(2025-03-06 to 2025-03-13)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`e3e32b64` ➡️ `6607cf78`](https://github.com/nixos/nixpkgs/compare/e3e32b642a31e6714ec1b712de8c91a3352ce7e1...6607cf789e541e7873d40d3a8f7815ea92204f32) <sub>(2025-03-09 to 2025-03-13)</sub>
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`a3f70463` ➡️ `f833a338`](https://github.com/catppuccin/nix/compare/a3f70463fb5e3df32d2d52a2705606db03843de2...f833a338ff6c091c84e041ee77ce88f8b242ca79) <sub>(2025-03-11 to 2025-03-14)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`e653d71e` ➡️ `d016ce03`](https://github.com/Mic92/sops-nix/compare/e653d71e82575a43fe9d228def8eddb73887b866...d016ce0365b87d848a57c12ffcfdc71da7a2b55f) <sub>(2025-03-10 to 2025-03-13)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`18780912` ➡️ `4e12151c`](https://github.com/nix-community/home-manager/compare/18780912345970e5b546b1b085385789b6935a83...4e12151c9e014e2449e0beca2c0e9534b96a26b4) <sub>(2025-03-12 to 2025-03-14)</sub>