### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1742098205,
-        "narHash": "sha256-gCkVTohFTyq/Pi3dlUhv1uA5Kqbalf45nLmUDRluULE=",
+        "lastModified": 1742599566,
+        "narHash": "sha256-xr6ntmiUPXSh9o9mJ7og9vxALMQs1EQhIhWUAO2D1M0=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "d84df59c7aa29cebaff9f190d19c24e7ddacd773",
+        "rev": "5e303e8d7e251868fa79f83bbda69da90aa62402",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741955947,
-        "narHash": "sha256-2lbURKclgKqBNm7hVRtWh0A7NrdsibD0EaWhahUVhhY=",
+        "lastModified": 1742588233,
+        "narHash": "sha256-Fi5g8H5FXMSRqy+mU6gPG0v+C9pzjYbkkiePtz8+PpA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4e12151c9e014e2449e0beca2c0e9534b96a26b4",
+        "rev": "296ddc64627f4a6a4eb447852d7346b9dd16197d",
         "type": "github"
       },
       "original": {
@@ -261,11 +261,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1740765362,
-        "narHash": "sha256-QmF+wyFzudTB3Dq2i9acY/nhc8uRiD+p7iG+V1Q5neE=",
+        "lastModified": 1742482360,
+        "narHash": "sha256-B1CsQ7DameEzwdl3mQN0D6E3LA8eJ2XPj4BWufoKjP8=",
         "owner": "hyprwm",
         "repo": "hyprpaper",
-        "rev": "6f4ba431638e44478417b9f524fb1771e5eda83c",
+        "rev": "05337a4595aa03eedec33f48004e46092917a5ca",
         "type": "github"
       },
       "original": {
@@ -375,11 +375,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1742180333,
-        "narHash": "sha256-SrvP0G0fxz35lvQxBhAeJOl6+BueIsxJ4azMX+l/kAU=",
+        "lastModified": 1742376361,
+        "narHash": "sha256-VFMgJkp/COvkt5dnkZB4D2szVdmF6DGm5ZdVvTUy61c=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "113cd3916682def185290145924fa30b30bda972",
+        "rev": "daaae13dff0ecc692509a1332ff9003d9952d7a9",
         "type": "github"
       },
       "original": {
@@ -464,11 +464,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1741851582,
-        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
+        "lastModified": 1742288794,
+        "narHash": "sha256-Txwa5uO+qpQXrNG4eumPSD+hHzzYi/CdaM80M9XRLCo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
+        "rev": "b6eaf97c6960d97350c584de1b6dcff03c9daf42",
         "type": "github"
       },
       "original": {
@@ -480,11 +480,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1742069588,
-        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
+        "lastModified": 1742422364,
+        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
+        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
         "type": "github"
       },
       "original": {
@@ -628,11 +628,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741861888,
-        "narHash": "sha256-ynOgXAyToeE1UdLNfrUn/hL7MN0OpIS2BtNdLjpjPf0=",
+        "lastModified": 1742595978,
+        "narHash": "sha256-05onsoMrLyXE4XleDCeLC3bXnC4nyUbKWInGwM7v6hU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d016ce0365b87d848a57c12ffcfdc71da7a2b55f",
+        "rev": "b7756921b002de60fb66782effad3ce8bdb5b25d",
         "type": "github"
       },
       "original": {
@@ -699,11 +699,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1740745001,
-        "narHash": "sha256-XZEIwnwOYgb1wECvT83HB314bd/JBYwSaTaj2EeqWrc=",
+        "lastModified": 1742568003,
+        "narHash": "sha256-xd24h5CHAGJG3PdR++snVX2gE/SCc6mP659Xb1WlIfU=",
         "owner": "abenz1267",
         "repo": "walker",
-        "rev": "350d5e078b997b5ca07eda39e207048ee26bbb9d",
+        "rev": "ee366f5e717183a01ad34807e95c8dfa285a7339",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/d84df59c7aa29cebaff9f190d19c24e7ddacd773' (2025-03-16)
  → 'github:catppuccin/nix/5e303e8d7e251868fa79f83bbda69da90aa62402' (2025-03-21)
• Updated input 'catppuccin/nixpkgs':
    'github:NixOS/nixpkgs/6607cf789e541e7873d40d3a8f7815ea92204f32' (2025-03-13)
  → 'github:NixOS/nixpkgs/b6eaf97c6960d97350c584de1b6dcff03c9daf42' (2025-03-18)
• Updated input 'home-manager':
    'github:nix-community/home-manager/4e12151c9e014e2449e0beca2c0e9534b96a26b4' (2025-03-14)
  → 'github:nix-community/home-manager/296ddc64627f4a6a4eb447852d7346b9dd16197d' (2025-03-21)
• Updated input 'hyprpaper':
    'github:hyprwm/hyprpaper/6f4ba431638e44478417b9f524fb1771e5eda83c' (2025-02-28)
  → 'github:hyprwm/hyprpaper/05337a4595aa03eedec33f48004e46092917a5ca' (2025-03-20)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/113cd3916682def185290145924fa30b30bda972' (2025-03-17)
  → 'github:NixOS/nixos-hardware/daaae13dff0ecc692509a1332ff9003d9952d7a9' (2025-03-19)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5' (2025-03-15)
  → 'github:nixos/nixpkgs/a84ebe20c6bc2ecbcfb000a50776219f48d134cc' (2025-03-19)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/d016ce0365b87d848a57c12ffcfdc71da7a2b55f' (2025-03-13)
  → 'github:Mic92/sops-nix/b7756921b002de60fb66782effad3ce8bdb5b25d' (2025-03-21)
• Updated input 'walker':
    'github:abenz1267/walker/350d5e078b997b5ca07eda39e207048ee26bbb9d' (2025-02-28)
  → 'github:abenz1267/walker/ee366f5e717183a01ad34807e95c8dfa285a7339' (2025-03-21)

```

</p></details>

 - Updated input [`catppuccin/nixpkgs`](https://github.com/NixOS/nixpkgs): [`6607cf78` ➡️ `b6eaf97c`](https://github.com/NixOS/nixpkgs/compare/6607cf789e541e7873d40d3a8f7815ea92204f32...b6eaf97c6960d97350c584de1b6dcff03c9daf42) <sub>(2025-03-13 to 2025-03-18)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`c80f6a7e` ➡️ `a84ebe20`](https://github.com/nixos/nixpkgs/compare/c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5...a84ebe20c6bc2ecbcfb000a50776219f48d134cc) <sub>(2025-03-15 to 2025-03-19)</sub>
 - Updated input [`hyprpaper`](https://github.com/hyprwm/hyprpaper): [`6f4ba431` ➡️ `05337a45`](https://github.com/hyprwm/hyprpaper/compare/6f4ba431638e44478417b9f524fb1771e5eda83c...05337a4595aa03eedec33f48004e46092917a5ca) <sub>(2025-02-28 to 2025-03-20)</sub>
 - Updated input [`walker`](https://github.com/abenz1267/walker): [`350d5e07` ➡️ `ee366f5e`](https://github.com/abenz1267/walker/compare/350d5e078b997b5ca07eda39e207048ee26bbb9d...ee366f5e717183a01ad34807e95c8dfa285a7339) <sub>(2025-02-28 to 2025-03-21)</sub>
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`d84df59c` ➡️ `5e303e8d`](https://github.com/catppuccin/nix/compare/d84df59c7aa29cebaff9f190d19c24e7ddacd773...5e303e8d7e251868fa79f83bbda69da90aa62402) <sub>(2025-03-16 to 2025-03-21)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`d016ce03` ➡️ `b7756921`](https://github.com/Mic92/sops-nix/compare/d016ce0365b87d848a57c12ffcfdc71da7a2b55f...b7756921b002de60fb66782effad3ce8bdb5b25d) <sub>(2025-03-13 to 2025-03-21)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`4e12151c` ➡️ `296ddc64`](https://github.com/nix-community/home-manager/compare/4e12151c9e014e2449e0beca2c0e9534b96a26b4...296ddc64627f4a6a4eb447852d7346b9dd16197d) <sub>(2025-03-14 to 2025-03-21)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`113cd391` ➡️ `daaae13d`](https://github.com/NixOS/nixos-hardware/compare/113cd3916682def185290145924fa30b30bda972...daaae13dff0ecc692509a1332ff9003d9952d7a9) <sub>(2025-03-17 to 2025-03-19)</sub>