### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -375,11 +375,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1742806253,
-        "narHash": "sha256-zvQ4GsCJT6MTOzPKLmlFyM+lxo0JGQ0cSFaZSACmWfY=",
+        "lastModified": 1743167577,
+        "narHash": "sha256-I09SrXIO0UdyBFfh0fxDq5WnCDg8XKmZ1HQbaXzMA1k=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ecaa2d911e77c265c2a5bac8b583c40b0f151726",
+        "rev": "0ed819e708af17bfc4bbc63ee080ef308a24aa42",
         "type": "github"
       },
       "original": {
@@ -480,11 +480,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1742889210,
-        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
+        "lastModified": 1743095683,
+        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
+        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/ecaa2d911e77c265c2a5bac8b583c40b0f151726' (2025-03-24)
  → 'github:NixOS/nixos-hardware/0ed819e708af17bfc4bbc63ee080ef308a24aa42' (2025-03-28)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/698214a32beb4f4c8e3942372c694f40848b360d' (2025-03-25)
  → 'github:nixos/nixpkgs/5e5402ecbcb27af32284d4a62553c019a3a49ea6' (2025-03-27)

```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`698214a3` ➡️ `5e5402ec`](https://github.com/nixos/nixpkgs/compare/698214a32beb4f4c8e3942372c694f40848b360d...5e5402ecbcb27af32284d4a62553c019a3a49ea6) <sub>(2025-03-25 to 2025-03-27)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`ecaa2d91` ➡️ `0ed819e7`](https://github.com/NixOS/nixos-hardware/compare/ecaa2d911e77c265c2a5bac8b583c40b0f151726...0ed819e708af17bfc4bbc63ee080ef308a24aa42) <sub>(2025-03-24 to 2025-03-28)</sub>