### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1743362584,
-        "narHash": "sha256-21gRjeM2noB486udCyzWxeKemNfZrh1lv8Z/zM5WYMY=",
+        "lastModified": 1743801669,
+        "narHash": "sha256-RxQQQCGqywOPbdNrWGbFyFdcrdrXM4YBHW7vYt13OeI=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "4f55f5493c1607fe55fad8349ad969ad1600499c",
+        "rev": "07beb389d69a52c4dd5895da9553463c3740a26a",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741786315,
-        "narHash": "sha256-VT65AE2syHVj6v/DGB496bqBnu1PXrrzwlw07/Zpllc=",
+        "lastModified": 1743598667,
+        "narHash": "sha256-ViE7NoFWytYO2uJONTAX35eGsvTYXNHjWALeHAg8OQY=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "0d8c6ad4a43906d14abd5c60e0ffe7b587b213de",
+        "rev": "329d3d7e8bc63dd30c39e14e6076db590a6eabe6",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743360001,
-        "narHash": "sha256-HtpS/ZdgWXw0y+aFdORcX5RuBGTyz3WskThspNR70SM=",
+        "lastModified": 1743788974,
+        "narHash": "sha256-2LeVyQZI2wTkSzMLvnN/kJjXVWp4HCVUoq17Bv8TNTk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b6fd653ef8fbeccfd4958650757e91767a65506d",
+        "rev": "0f5908daf890c3d7e7052bef1d6deb0f2710aaa1",
         "type": "github"
       },
       "original": {
@@ -375,11 +375,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1743167577,
-        "narHash": "sha256-I09SrXIO0UdyBFfh0fxDq5WnCDg8XKmZ1HQbaXzMA1k=",
+        "lastModified": 1743420942,
+        "narHash": "sha256-b/exDDQSLmENZZgbAEI3qi9yHkuXAXCPbormD8CSJXo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0ed819e708af17bfc4bbc63ee080ef308a24aa42",
+        "rev": "de6fc5551121c59c01e2a3d45b277a6d05077bc4",
         "type": "github"
       },
       "original": {
@@ -464,11 +464,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1742288794,
-        "narHash": "sha256-Txwa5uO+qpQXrNG4eumPSD+hHzzYi/CdaM80M9XRLCo=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6eaf97c6960d97350c584de1b6dcff03c9daf42",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {
@@ -480,11 +480,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1743315132,
-        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {
@@ -628,11 +628,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743305778,
-        "narHash": "sha256-Ux/UohNtnM5mn9SFjaHp6IZe2aAnUCzklMluNtV6zFo=",
+        "lastModified": 1743756170,
+        "narHash": "sha256-2b11EYa08oqDmF3zEBLkG1AoNn9rB1k39ew/T/mSvbU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8e873886bbfc32163fe027b8676c75637b7da114",
+        "rev": "cff8437c5fe8c68fc3a840a21bf1f4dc801da40d",
         "type": "github"
       },
       "original": {
@@ -699,11 +699,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1743355773,
-        "narHash": "sha256-NF5B5v9QYMGa1BtGUnTHBcaoYsvLj87yJuFcTqVOMDc=",
+        "lastModified": 1743685641,
+        "narHash": "sha256-tCZRh2HxkdDeDQ6SuTFakZveI+Eg+3lpEMrU2qYF1Bo=",
         "owner": "abenz1267",
         "repo": "walker",
-        "rev": "a17228a9f4e30cc94139b1243267f19e499ad505",
+        "rev": "4d94aaaa2f3c98b5e6f4dea889baddb4bb2dd3ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/4f55f5493c1607fe55fad8349ad969ad1600499c' (2025-03-30)
  → 'github:catppuccin/nix/07beb389d69a52c4dd5895da9553463c3740a26a' (2025-04-04)
• Updated input 'catppuccin/nixpkgs':
    'github:NixOS/nixpkgs/b6eaf97c6960d97350c584de1b6dcff03c9daf42' (2025-03-18)
  → 'github:NixOS/nixpkgs/2c8d3f48d33929642c1c12cd243df4cc7d2ce434' (2025-04-02)
• Updated input 'disko':
    'github:nix-community/disko/0d8c6ad4a43906d14abd5c60e0ffe7b587b213de' (2025-03-12)
  → 'github:nix-community/disko/329d3d7e8bc63dd30c39e14e6076db590a6eabe6' (2025-04-02)
• Updated input 'home-manager':
    'github:nix-community/home-manager/b6fd653ef8fbeccfd4958650757e91767a65506d' (2025-03-30)
  → 'github:nix-community/home-manager/0f5908daf890c3d7e7052bef1d6deb0f2710aaa1' (2025-04-04)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/0ed819e708af17bfc4bbc63ee080ef308a24aa42' (2025-03-28)
  → 'github:NixOS/nixos-hardware/de6fc5551121c59c01e2a3d45b277a6d05077bc4' (2025-03-31)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/52faf482a3889b7619003c0daec593a1912fddc1' (2025-03-30)
  → 'github:nixos/nixpkgs/2c8d3f48d33929642c1c12cd243df4cc7d2ce434' (2025-04-02)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/8e873886bbfc32163fe027b8676c75637b7da114' (2025-03-30)
  → 'github:Mic92/sops-nix/cff8437c5fe8c68fc3a840a21bf1f4dc801da40d' (2025-04-04)
• Updated input 'walker':
    'github:abenz1267/walker/a17228a9f4e30cc94139b1243267f19e499ad505' (2025-03-30)
  → 'github:abenz1267/walker/4d94aaaa2f3c98b5e6f4dea889baddb4bb2dd3ca' (2025-04-03)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`0d8c6ad4` ➡️ `329d3d7e`](https://github.com/nix-community/disko/compare/0d8c6ad4a43906d14abd5c60e0ffe7b587b213de...329d3d7e8bc63dd30c39e14e6076db590a6eabe6) <sub>(2025-03-12 to 2025-04-02)</sub>
 - Updated input [`catppuccin/nixpkgs`](https://github.com/NixOS/nixpkgs): [`b6eaf97c` ➡️ `2c8d3f48`](https://github.com/NixOS/nixpkgs/compare/b6eaf97c6960d97350c584de1b6dcff03c9daf42...2c8d3f48d33929642c1c12cd243df4cc7d2ce434) <sub>(2025-03-18 to 2025-04-02)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`52faf482` ➡️ `2c8d3f48`](https://github.com/nixos/nixpkgs/compare/52faf482a3889b7619003c0daec593a1912fddc1...2c8d3f48d33929642c1c12cd243df4cc7d2ce434) <sub>(2025-03-30 to 2025-04-02)</sub>
 - Updated input [`walker`](https://github.com/abenz1267/walker): [`a17228a9` ➡️ `4d94aaaa`](https://github.com/abenz1267/walker/compare/a17228a9f4e30cc94139b1243267f19e499ad505...4d94aaaa2f3c98b5e6f4dea889baddb4bb2dd3ca) <sub>(2025-03-30 to 2025-04-03)</sub>
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`4f55f549` ➡️ `07beb389`](https://github.com/catppuccin/nix/compare/4f55f5493c1607fe55fad8349ad969ad1600499c...07beb389d69a52c4dd5895da9553463c3740a26a) <sub>(2025-03-30 to 2025-04-04)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`8e873886` ➡️ `cff8437c`](https://github.com/Mic92/sops-nix/compare/8e873886bbfc32163fe027b8676c75637b7da114...cff8437c5fe8c68fc3a840a21bf1f4dc801da40d) <sub>(2025-03-30 to 2025-04-04)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`b6fd653e` ➡️ `0f5908da`](https://github.com/nix-community/home-manager/compare/b6fd653ef8fbeccfd4958650757e91767a65506d...0f5908daf890c3d7e7052bef1d6deb0f2710aaa1) <sub>(2025-03-30 to 2025-04-04)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`0ed819e7` ➡️ `de6fc555`](https://github.com/NixOS/nixos-hardware/compare/0ed819e708af17bfc4bbc63ee080ef308a24aa42...de6fc5551121c59c01e2a3d45b277a6d05077bc4) <sub>(2025-03-28 to 2025-03-31)</sub>