### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1743362584,
-        "narHash": "sha256-21gRjeM2noB486udCyzWxeKemNfZrh1lv8Z/zM5WYMY=",
+        "lastModified": 1744375180,
+        "narHash": "sha256-s2FmOufSMIz6H0UrGOHJ7RrQfqvhCjUIvk54J8LlZFA=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "4f55f5493c1607fe55fad8349ad969ad1600499c",
+        "rev": "75c26f52a685291fedfd3a9c93f5cbe80a5d3321",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741786315,
-        "narHash": "sha256-VT65AE2syHVj6v/DGB496bqBnu1PXrrzwlw07/Zpllc=",
+        "lastModified": 1744145203,
+        "narHash": "sha256-I2oILRiJ6G+BOSjY+0dGrTPe080L3pbKpc+gCV3Nmyk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "0d8c6ad4a43906d14abd5c60e0ffe7b587b213de",
+        "rev": "76c0a6dba345490508f36c1aa3c7ba5b6b460989",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743360001,
-        "narHash": "sha256-HtpS/ZdgWXw0y+aFdORcX5RuBGTyz3WskThspNR70SM=",
+        "lastModified": 1744400600,
+        "narHash": "sha256-qYhUgA98mhq1QK13r9qVY+sG1ri6FBgyp+GApX6wS20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b6fd653ef8fbeccfd4958650757e91767a65506d",
+        "rev": "b74b22bb6167e8dff083ec6988c98798bf8954d3",
         "type": "github"
       },
       "original": {
@@ -375,11 +375,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1743167577,
-        "narHash": "sha256-I09SrXIO0UdyBFfh0fxDq5WnCDg8XKmZ1HQbaXzMA1k=",
+        "lastModified": 1744366945,
+        "narHash": "sha256-OuLhysErPHl53BBifhesrRumJNhrlSgQDfYOTXfgIMg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0ed819e708af17bfc4bbc63ee080ef308a24aa42",
+        "rev": "1fe3cc2bc5d2dc9c81cb4e63d2f67c1543340df1",
         "type": "github"
       },
       "original": {
@@ -464,11 +464,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1742288794,
-        "narHash": "sha256-Txwa5uO+qpQXrNG4eumPSD+hHzzYi/CdaM80M9XRLCo=",
+        "lastModified": 1744098102,
+        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6eaf97c6960d97350c584de1b6dcff03c9daf42",
+        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
         "type": "github"
       },
       "original": {
@@ -480,11 +480,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1743315132,
-        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
+        "lastModified": 1744232761,
+        "narHash": "sha256-gbl9hE39nQRpZaLjhWKmEu5ejtQsgI5TWYrIVVJn30U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
+        "rev": "f675531bc7e6657c10a18b565cfebd8aa9e24c14",
         "type": "github"
       },
       "original": {
@@ -628,11 +628,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743305778,
-        "narHash": "sha256-Ux/UohNtnM5mn9SFjaHp6IZe2aAnUCzklMluNtV6zFo=",
+        "lastModified": 1744103455,
+        "narHash": "sha256-SR6+qjkPjGQG+8eM4dCcVtss8r9bre/LAxFMPJpaZeU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8e873886bbfc32163fe027b8676c75637b7da114",
+        "rev": "69d5a5a4635c27dae5a742f36108beccc506c1ba",
         "type": "github"
       },
       "original": {
@@ -699,11 +699,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1743355773,
-        "narHash": "sha256-NF5B5v9QYMGa1BtGUnTHBcaoYsvLj87yJuFcTqVOMDc=",
+        "lastModified": 1744044972,
+        "narHash": "sha256-17L0FA2S3+237RN2o/gKnIyBmfoChVxyrGiYPAovpSU=",
         "owner": "abenz1267",
         "repo": "walker",
-        "rev": "a17228a9f4e30cc94139b1243267f19e499ad505",
+        "rev": "b2b47b27ac64b1a9820216520ad61c3989d27c87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/4f55f5493c1607fe55fad8349ad969ad1600499c' (2025-03-30)
  → 'github:catppuccin/nix/75c26f52a685291fedfd3a9c93f5cbe80a5d3321' (2025-04-11)
• Updated input 'catppuccin/nixpkgs':
    'github:NixOS/nixpkgs/b6eaf97c6960d97350c584de1b6dcff03c9daf42' (2025-03-18)
  → 'github:NixOS/nixpkgs/c8cd81426f45942bb2906d5ed2fe21d2f19d95b7' (2025-04-08)
• Updated input 'disko':
    'github:nix-community/disko/0d8c6ad4a43906d14abd5c60e0ffe7b587b213de' (2025-03-12)
  → 'github:nix-community/disko/76c0a6dba345490508f36c1aa3c7ba5b6b460989' (2025-04-08)
• Updated input 'home-manager':
    'github:nix-community/home-manager/b6fd653ef8fbeccfd4958650757e91767a65506d' (2025-03-30)
  → 'github:nix-community/home-manager/b74b22bb6167e8dff083ec6988c98798bf8954d3' (2025-04-11)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/0ed819e708af17bfc4bbc63ee080ef308a24aa42' (2025-03-28)
  → 'github:NixOS/nixos-hardware/1fe3cc2bc5d2dc9c81cb4e63d2f67c1543340df1' (2025-04-11)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/52faf482a3889b7619003c0daec593a1912fddc1' (2025-03-30)
  → 'github:nixos/nixpkgs/f675531bc7e6657c10a18b565cfebd8aa9e24c14' (2025-04-09)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/8e873886bbfc32163fe027b8676c75637b7da114' (2025-03-30)
  → 'github:Mic92/sops-nix/69d5a5a4635c27dae5a742f36108beccc506c1ba' (2025-04-08)
• Updated input 'walker':
    'github:abenz1267/walker/a17228a9f4e30cc94139b1243267f19e499ad505' (2025-03-30)
  → 'github:abenz1267/walker/b2b47b27ac64b1a9820216520ad61c3989d27c87' (2025-04-07)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`0d8c6ad4` ➡️ `76c0a6db`](https://github.com/nix-community/disko/compare/0d8c6ad4a43906d14abd5c60e0ffe7b587b213de...76c0a6dba345490508f36c1aa3c7ba5b6b460989) <sub>(2025-03-12 to 2025-04-08)</sub>
 - Updated input [`catppuccin/nixpkgs`](https://github.com/NixOS/nixpkgs): [`b6eaf97c` ➡️ `c8cd8142`](https://github.com/NixOS/nixpkgs/compare/b6eaf97c6960d97350c584de1b6dcff03c9daf42...c8cd81426f45942bb2906d5ed2fe21d2f19d95b7) <sub>(2025-03-18 to 2025-04-08)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`52faf482` ➡️ `f675531b`](https://github.com/nixos/nixpkgs/compare/52faf482a3889b7619003c0daec593a1912fddc1...f675531bc7e6657c10a18b565cfebd8aa9e24c14) <sub>(2025-03-30 to 2025-04-09)</sub>
 - Updated input [`walker`](https://github.com/abenz1267/walker): [`a17228a9` ➡️ `b2b47b27`](https://github.com/abenz1267/walker/compare/a17228a9f4e30cc94139b1243267f19e499ad505...b2b47b27ac64b1a9820216520ad61c3989d27c87) <sub>(2025-03-30 to 2025-04-07)</sub>
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`4f55f549` ➡️ `75c26f52`](https://github.com/catppuccin/nix/compare/4f55f5493c1607fe55fad8349ad969ad1600499c...75c26f52a685291fedfd3a9c93f5cbe80a5d3321) <sub>(2025-03-30 to 2025-04-11)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`8e873886` ➡️ `69d5a5a4`](https://github.com/Mic92/sops-nix/compare/8e873886bbfc32163fe027b8676c75637b7da114...69d5a5a4635c27dae5a742f36108beccc506c1ba) <sub>(2025-03-30 to 2025-04-08)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`b6fd653e` ➡️ `b74b22bb`](https://github.com/nix-community/home-manager/compare/b6fd653ef8fbeccfd4958650757e91767a65506d...b74b22bb6167e8dff083ec6988c98798bf8954d3) <sub>(2025-03-30 to 2025-04-11)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`0ed819e7` ➡️ `1fe3cc2b`](https://github.com/NixOS/nixos-hardware/compare/0ed819e708af17bfc4bbc63ee080ef308a24aa42...1fe3cc2bc5d2dc9c81cb4e63d2f67c1543340df1) <sub>(2025-03-28 to 2025-04-11)</sub>