### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1744447794,
-        "narHash": "sha256-z5uK5BDmFg0L/0EW2XYLGr39FbQeXyNVnIEhkZrG8+Q=",
+        "lastModified": 1745006048,
+        "narHash": "sha256-4ONXaEwnyZGPp84d6wjiqoR4xyTWygUobBTcSkILPzU=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "c44fe73ed8e5d5809eded7cc6156ca9c40044e42",
+        "rev": "592094a02c4e43a9fa33559ade84d1ca015e8ada",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744145203,
-        "narHash": "sha256-I2oILRiJ6G+BOSjY+0dGrTPe080L3pbKpc+gCV3Nmyk=",
+        "lastModified": 1744940522,
+        "narHash": "sha256-TNoetfICvd29DhxRPpmyKItQBDlqSvKcV+wGNkn14jk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "76c0a6dba345490508f36c1aa3c7ba5b6b460989",
+        "rev": "51d33bbb7f1e74ba5f9d9a77357735149da99081",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744618730,
-        "narHash": "sha256-n3gN7aHwVRnnBZI64EDoKyJnWidNYJ0xezhqQtdjH2Q=",
+        "lastModified": 1745016969,
+        "narHash": "sha256-nDK8Z+LsNWrUsQ1JjnndNB57lvCmvy2QZUoCakoJCcI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "85dd758c703ffbf9d97f34adcef3a898b54b4014",
+        "rev": "67f60ebce88a89939fb509f304ac554bcdc5bfa6",
         "type": "github"
       },
       "original": {
@@ -464,11 +464,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1744098102,
-        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "type": "github"
       },
       "original": {
@@ -480,11 +480,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1744463964,
-        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "lastModified": 1744932701,
+        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
         "type": "github"
       },
       "original": {
@@ -628,11 +628,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744518500,
-        "narHash": "sha256-lv52pnfiRGp5+xkZEgWr56DWiRgkMFXpiGba3eJ3krE=",
+        "lastModified": 1744669848,
+        "narHash": "sha256-pXyanHLUzLNd3MX9vsWG+6Z2hTU8niyphWstYEP3/GU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "7e147a1ae90f0d4a374938cdc3df3cdaecb9d388",
+        "rev": "61154300d945f0b147b30d24ddcafa159148026a",
         "type": "github"
       },
       "original": {
@@ -699,11 +699,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1744044972,
-        "narHash": "sha256-17L0FA2S3+237RN2o/gKnIyBmfoChVxyrGiYPAovpSU=",
+        "lastModified": 1744983111,
+        "narHash": "sha256-isY72TRj/XTVVaEDc/i8+JZMTMpPHkUKHV1HWYrFc+w=",
         "owner": "abenz1267",
         "repo": "walker",
-        "rev": "b2b47b27ac64b1a9820216520ad61c3989d27c87",
+        "rev": "a7dd5ca41bf8ca5b9ad6fa0ce3ef6ef48fd632d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/c44fe73ed8e5d5809eded7cc6156ca9c40044e42' (2025-04-12)
  → 'github:catppuccin/nix/592094a02c4e43a9fa33559ade84d1ca015e8ada' (2025-04-18)
• Updated input 'catppuccin/nixpkgs':
    'github:NixOS/nixpkgs/c8cd81426f45942bb2906d5ed2fe21d2f19d95b7' (2025-04-08)
  → 'github:NixOS/nixpkgs/2631b0b7abcea6e640ce31cd78ea58910d31e650' (2025-04-12)
• Updated input 'disko':
    'github:nix-community/disko/76c0a6dba345490508f36c1aa3c7ba5b6b460989' (2025-04-08)
  → 'github:nix-community/disko/51d33bbb7f1e74ba5f9d9a77357735149da99081' (2025-04-18)
• Updated input 'home-manager':
    'github:nix-community/home-manager/85dd758c703ffbf9d97f34adcef3a898b54b4014' (2025-04-14)
  → 'github:nix-community/home-manager/67f60ebce88a89939fb509f304ac554bcdc5bfa6' (2025-04-18)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/2631b0b7abcea6e640ce31cd78ea58910d31e650' (2025-04-12)
  → 'github:nixos/nixpkgs/b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef' (2025-04-17)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/7e147a1ae90f0d4a374938cdc3df3cdaecb9d388' (2025-04-13)
  → 'github:Mic92/sops-nix/61154300d945f0b147b30d24ddcafa159148026a' (2025-04-14)
• Updated input 'walker':
    'github:abenz1267/walker/b2b47b27ac64b1a9820216520ad61c3989d27c87' (2025-04-07)
  → 'github:abenz1267/walker/a7dd5ca41bf8ca5b9ad6fa0ce3ef6ef48fd632d5' (2025-04-18)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`76c0a6db` ➡️ `51d33bbb`](https://github.com/nix-community/disko/compare/76c0a6dba345490508f36c1aa3c7ba5b6b460989...51d33bbb7f1e74ba5f9d9a77357735149da99081) <sub>(2025-04-08 to 2025-04-18)</sub>
 - Updated input [`catppuccin/nixpkgs`](https://github.com/NixOS/nixpkgs): [`c8cd8142` ➡️ `2631b0b7`](https://github.com/NixOS/nixpkgs/compare/c8cd81426f45942bb2906d5ed2fe21d2f19d95b7...2631b0b7abcea6e640ce31cd78ea58910d31e650) <sub>(2025-04-08 to 2025-04-12)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`2631b0b7` ➡️ `b024ced1`](https://github.com/nixos/nixpkgs/compare/2631b0b7abcea6e640ce31cd78ea58910d31e650...b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef) <sub>(2025-04-12 to 2025-04-17)</sub>
 - Updated input [`walker`](https://github.com/abenz1267/walker): [`b2b47b27` ➡️ `a7dd5ca4`](https://github.com/abenz1267/walker/compare/b2b47b27ac64b1a9820216520ad61c3989d27c87...a7dd5ca41bf8ca5b9ad6fa0ce3ef6ef48fd632d5) <sub>(2025-04-07 to 2025-04-18)</sub>
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`c44fe73e` ➡️ `592094a0`](https://github.com/catppuccin/nix/compare/c44fe73ed8e5d5809eded7cc6156ca9c40044e42...592094a02c4e43a9fa33559ade84d1ca015e8ada) <sub>(2025-04-12 to 2025-04-18)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`7e147a1a` ➡️ `61154300`](https://github.com/Mic92/sops-nix/compare/7e147a1ae90f0d4a374938cdc3df3cdaecb9d388...61154300d945f0b147b30d24ddcafa159148026a) <sub>(2025-04-13 to 2025-04-14)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`85dd758c` ➡️ `67f60ebc`](https://github.com/nix-community/home-manager/compare/85dd758c703ffbf9d97f34adcef3a898b54b4014...67f60ebce88a89939fb509f304ac554bcdc5bfa6) <sub>(2025-04-14 to 2025-04-18)</sub>