### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1746175539,
-        "narHash": "sha256-/wjcn1CDQqOhwOoYKS8Xp0KejrdXSJZQMF1CbbrVtMw=",
+        "lastModified": 1746650299,
+        "narHash": "sha256-4+pxk1KcSH8ww3tgN808nNJ3E7Q8gNWI+U0sesW7mBQ=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "a5db9e41a4dccfa5ffe38e6f1841a5f9ad5c5c04",
+        "rev": "f746600f15b69df05c84e3037749a3be5b1276d1",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746411114,
-        "narHash": "sha256-mLlkVX1kKbAa/Ns5u26wDYw4YW4ziMFM21fhtRmfirU=",
+        "lastModified": 1746729224,
+        "narHash": "sha256-9R4sOLAK1w3Bq54H3XOJogdc7a6C2bLLmatOQ+5pf5w=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "b5d1320ebc2f34dbea4655f95167f55e2130cdb3",
+        "rev": "85555d27ded84604ad6657ecca255a03fd878607",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746413188,
-        "narHash": "sha256-i6BoiQP0PasExESQHszC0reQHfO6D4aI2GzOwZMOI20=",
+        "lastModified": 1746798521,
+        "narHash": "sha256-axfz/jBEH9XHpS7YSumstV7b2PrPf7L8bhWUtLBv3nA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8a318641ac13d3bc0a53651feaee9560f9b2d89a",
+        "rev": "e95a7c5b6fa93304cd2fd78cf676c4f6d23c422c",
         "type": "github"
       },
       "original": {
@@ -228,11 +228,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738018829,
-        "narHash": "sha256-5Ol5iahMlELx3lWuChyZsqqLk6sP6aqaJCJFw92OZGo=",
+        "lastModified": 1745015490,
+        "narHash": "sha256-apEJ9zoSzmslhJ2vOKFcXTMZLUFYzh1ghfB6Rbw3Low=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "12cd7034e441a5ebfdef1a090c0788413b4a635b",
+        "rev": "60754910946b4e2dc1377b967b7156cb989c5873",
         "type": "github"
       },
       "original": {
@@ -257,11 +257,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737634606,
-        "narHash": "sha256-W7W87Cv6wqZ9PHegI6rH1+ve3zJPiyevMFf0/HwdbCQ=",
+        "lastModified": 1746655412,
+        "narHash": "sha256-kVQ0bHVtX6baYxRWWIh4u3LNJZb9Zcm2xBeDPOGz5BY=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "f41271d35cc0f370d300413d756c2677f386af9d",
+        "rev": "557241780c179cf7ef224df392f8e67dab6cef83",
         "type": "github"
       },
       "original": {
@@ -282,11 +282,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1742482360,
-        "narHash": "sha256-B1CsQ7DameEzwdl3mQN0D6E3LA8eJ2XPj4BWufoKjP8=",
+        "lastModified": 1746738843,
+        "narHash": "sha256-qe4OwoBal5fYoTDV8psE+1jAG8Qv5lJDfWqS/4hEHPU=",
         "owner": "hyprwm",
         "repo": "hyprpaper",
-        "rev": "05337a4595aa03eedec33f48004e46092917a5ca",
+        "rev": "99213a1854d172c529e815834e5b43dab95a3b67",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737978343,
-        "narHash": "sha256-TfFS0HCEJh63Kahrkp1h9hVDMdLU8a37Zz+IFucxyfA=",
+        "lastModified": 1746635225,
+        "narHash": "sha256-W9G9bb0zRYDBRseHbVez0J8qVpD5QbizX67H/vsudhM=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "6a8bc9d2a4451df12f5179dc0b1d2d46518a90ab",
+        "rev": "674ea57373f08b7609ce93baff131117a0dfe70d",
         "type": "github"
       },
       "original": {
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735493474,
-        "narHash": "sha256-fktzv4NaqKm94VAkAoVqO/nqQlw+X0/tJJNAeCSfzK4=",
+        "lastModified": 1739870480,
+        "narHash": "sha256-SiDN5BGxa/1hAsqhgJsS03C3t2QrLgBT8u+ENJ0Qzwc=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "de913476b59ee88685fdc018e77b8f6637a2ae0b",
+        "rev": "206367a08dc5ac4ba7ad31bdca391d098082e64b",
         "type": "github"
       },
       "original": {
@@ -351,11 +351,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1746275128,
-        "narHash": "sha256-8Ugyt7+tJtvPIiim7px5NVN+yofrqr9wXyl3YBRZC/A=",
+        "lastModified": 1746549778,
+        "narHash": "sha256-q3bZeVBcuXxfRJPP337D88C8dGoZbYZoum8xzQCVnms=",
         "owner": "ravitemer",
         "repo": "mcp-hub",
-        "rev": "64153349f4267bc0b6ca289b7ffaa190ff016c29",
+        "rev": "9357b1b6748c14182047890d928cb7f06632fc6d",
         "type": "github"
       },
       "original": {
@@ -369,11 +369,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1746194780,
-        "narHash": "sha256-CjPrTU/E62IdZ6GgEfpJ+GrFff6lp6K1S/yJ2j0nRQQ=",
+        "lastModified": 1746753921,
+        "narHash": "sha256-qznrDX+I2VMTIuZQZiPOCoyBqGOCn4ZXpQG6jPjL4DQ=",
         "owner": "natsukium",
         "repo": "mcp-servers-nix",
-        "rev": "d42b44e8fe733818de6780090521b05c23454f20",
+        "rev": "01699d8d2208c829b8d0b314240c3e4f7c0275d5",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1746468201,
-        "narHash": "sha256-hSOSlrvMJwGr8hX/gc0mnhUf5UIClMDUAadfXlSXzfc=",
+        "lastModified": 1746814339,
+        "narHash": "sha256-hf2lICJzwACWuzHCmZn5NI6LUAOgGdR1yh8ip+duyhk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "6aabf68429c0a414221d1790945babfb6a0bd068",
+        "rev": "3c5e12673265dfb0de3d9121420c0c2153bf21e0",
         "type": "github"
       },
       "original": {
@@ -570,11 +570,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1746328495,
-        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
+        "lastModified": 1746663147,
+        "narHash": "sha256-Ua0drDHawlzNqJnclTJGf87dBmaO/tn7iZ+TCkTRpRc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+        "rev": "dda3dcd3fe03e991015e9a74b22d35950f264a54",
         "type": "github"
       },
       "original": {
@@ -720,11 +720,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745310711,
-        "narHash": "sha256-ePyTpKEJTgX0gvgNQWd7tQYQ3glIkbqcW778RpHlqgA=",
+        "lastModified": 1746485181,
+        "narHash": "sha256-PxrrSFLaC7YuItShxmYbMgSuFFuwxBB+qsl9BZUnRvg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "5e3e92b16d6fdf9923425a8d4df7496b2434f39c",
+        "rev": "e93ee1d900ad264d65e9701a5c6f895683433386",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/a5db9e41a4dccfa5ffe38e6f1841a5f9ad5c5c04' (2025-05-02)
  → 'github:catppuccin/nix/f746600f15b69df05c84e3037749a3be5b1276d1' (2025-05-07)
• Updated input 'disko':
    'github:nix-community/disko/b5d1320ebc2f34dbea4655f95167f55e2130cdb3' (2025-05-05)
  → 'github:nix-community/disko/85555d27ded84604ad6657ecca255a03fd878607' (2025-05-08)
• Updated input 'home-manager':
    'github:nix-community/home-manager/8a318641ac13d3bc0a53651feaee9560f9b2d89a' (2025-05-05)
  → 'github:nix-community/home-manager/e95a7c5b6fa93304cd2fd78cf676c4f6d23c422c' (2025-05-09)
• Updated input 'hyprpaper':
    'github:hyprwm/hyprpaper/05337a4595aa03eedec33f48004e46092917a5ca' (2025-03-20)
  → 'github:hyprwm/hyprpaper/99213a1854d172c529e815834e5b43dab95a3b67' (2025-05-08)
• Updated input 'hyprpaper/hyprgraphics':
    'github:hyprwm/hyprgraphics/12cd7034e441a5ebfdef1a090c0788413b4a635b' (2025-01-27)
  → 'github:hyprwm/hyprgraphics/60754910946b4e2dc1377b967b7156cb989c5873' (2025-04-18)
• Updated input 'hyprpaper/hyprlang':
    'github:hyprwm/hyprlang/f41271d35cc0f370d300413d756c2677f386af9d' (2025-01-23)
  → 'github:hyprwm/hyprlang/557241780c179cf7ef224df392f8e67dab6cef83' (2025-05-07)
• Updated input 'hyprpaper/hyprutils':
    'github:hyprwm/hyprutils/6a8bc9d2a4451df12f5179dc0b1d2d46518a90ab' (2025-01-27)
  → 'github:hyprwm/hyprutils/674ea57373f08b7609ce93baff131117a0dfe70d' (2025-05-07)
• Updated input 'hyprpaper/hyprwayland-scanner':
    'github:hyprwm/hyprwayland-scanner/de913476b59ee88685fdc018e77b8f6637a2ae0b' (2024-12-29)
  → 'github:hyprwm/hyprwayland-scanner/206367a08dc5ac4ba7ad31bdca391d098082e64b' (2025-02-18)
• Updated input 'mcp-hub':
    'github:ravitemer/mcp-hub/64153349f4267bc0b6ca289b7ffaa190ff016c29' (2025-05-03)
  → 'github:ravitemer/mcp-hub/9357b1b6748c14182047890d928cb7f06632fc6d' (2025-05-06)
• Updated input 'mcp-servers-nix':
    'github:natsukium/mcp-servers-nix/d42b44e8fe733818de6780090521b05c23454f20' (2025-05-02)
  → 'github:natsukium/mcp-servers-nix/01699d8d2208c829b8d0b314240c3e4f7c0275d5' (2025-05-09)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/6aabf68429c0a414221d1790945babfb6a0bd068' (2025-05-05)
  → 'github:NixOS/nixos-hardware/3c5e12673265dfb0de3d9121420c0c2153bf21e0' (2025-05-09)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/979daf34c8cacebcd917d540070b52a3c2b9b16e' (2025-05-04)
  → 'github:nixos/nixpkgs/dda3dcd3fe03e991015e9a74b22d35950f264a54' (2025-05-08)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/5e3e92b16d6fdf9923425a8d4df7496b2434f39c' (2025-04-22)
  → 'github:Mic92/sops-nix/e93ee1d900ad264d65e9701a5c6f895683433386' (2025-05-05)

```

</p></details>

 - Updated input [`hyprpaper/hyprlang`](https://github.com/hyprwm/hyprlang): [`f41271d3` ➡️ `55724178`](https://github.com/hyprwm/hyprlang/compare/f41271d35cc0f370d300413d756c2677f386af9d...557241780c179cf7ef224df392f8e67dab6cef83) <sub>(2025-01-23 to 2025-05-07)</sub>
 - Updated input [`disko`](https://github.com/nix-community/disko): [`b5d1320e` ➡️ `85555d27`](https://github.com/nix-community/disko/compare/b5d1320ebc2f34dbea4655f95167f55e2130cdb3...85555d27ded84604ad6657ecca255a03fd878607) <sub>(2025-05-05 to 2025-05-08)</sub>
 - Updated input [`mcp-servers-nix`](https://github.com/natsukium/mcp-servers-nix): [`d42b44e8` ➡️ `01699d8d`](https://github.com/natsukium/mcp-servers-nix/compare/d42b44e8fe733818de6780090521b05c23454f20...01699d8d2208c829b8d0b314240c3e4f7c0275d5) <sub>(2025-05-02 to 2025-05-09)</sub>
 - Updated input [`hyprpaper/hyprwayland-scanner`](https://github.com/hyprwm/hyprwayland-scanner): [`de913476` ➡️ `206367a0`](https://github.com/hyprwm/hyprwayland-scanner/compare/de913476b59ee88685fdc018e77b8f6637a2ae0b...206367a08dc5ac4ba7ad31bdca391d098082e64b) <sub>(2024-12-29 to 2025-02-18)</sub>
 - Updated input [`hyprpaper/hyprgraphics`](https://github.com/hyprwm/hyprgraphics): [`12cd7034` ➡️ `60754910`](https://github.com/hyprwm/hyprgraphics/compare/12cd7034e441a5ebfdef1a090c0788413b4a635b...60754910946b4e2dc1377b967b7156cb989c5873) <sub>(2025-01-27 to 2025-04-18)</sub>
 - Updated input [`mcp-hub`](https://github.com/ravitemer/mcp-hub): [`64153349` ➡️ `9357b1b6`](https://github.com/ravitemer/mcp-hub/compare/64153349f4267bc0b6ca289b7ffaa190ff016c29...9357b1b6748c14182047890d928cb7f06632fc6d) <sub>(2025-05-03 to 2025-05-06)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`979daf34` ➡️ `dda3dcd3`](https://github.com/nixos/nixpkgs/compare/979daf34c8cacebcd917d540070b52a3c2b9b16e...dda3dcd3fe03e991015e9a74b22d35950f264a54) <sub>(2025-05-04 to 2025-05-08)</sub>
 - Updated input [`hyprpaper/hyprutils`](https://github.com/hyprwm/hyprutils): [`6a8bc9d2` ➡️ `674ea573`](https://github.com/hyprwm/hyprutils/compare/6a8bc9d2a4451df12f5179dc0b1d2d46518a90ab...674ea57373f08b7609ce93baff131117a0dfe70d) <sub>(2025-01-27 to 2025-05-07)</sub>
 - Updated input [`hyprpaper`](https://github.com/hyprwm/hyprpaper): [`05337a45` ➡️ `99213a18`](https://github.com/hyprwm/hyprpaper/compare/05337a4595aa03eedec33f48004e46092917a5ca...99213a1854d172c529e815834e5b43dab95a3b67) <sub>(2025-03-20 to 2025-05-08)</sub>
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`a5db9e41` ➡️ `f746600f`](https://github.com/catppuccin/nix/compare/a5db9e41a4dccfa5ffe38e6f1841a5f9ad5c5c04...f746600f15b69df05c84e3037749a3be5b1276d1) <sub>(2025-05-02 to 2025-05-07)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`5e3e92b1` ➡️ `e93ee1d9`](https://github.com/Mic92/sops-nix/compare/5e3e92b16d6fdf9923425a8d4df7496b2434f39c...e93ee1d900ad264d65e9701a5c6f895683433386) <sub>(2025-04-22 to 2025-05-05)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`8a318641` ➡️ `e95a7c5b`](https://github.com/nix-community/home-manager/compare/8a318641ac13d3bc0a53651feaee9560f9b2d89a...e95a7c5b6fa93304cd2fd78cf676c4f6d23c422c) <sub>(2025-05-05 to 2025-05-09)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`6aabf684` ➡️ `3c5e1267`](https://github.com/NixOS/nixos-hardware/compare/6aabf68429c0a414221d1790945babfb6a0bd068...3c5e12673265dfb0de3d9121420c0c2153bf21e0) <sub>(2025-05-05 to 2025-05-09)</sub>