### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1746896926,
-        "narHash": "sha256-rrpqPPUI+8xJ2ye2UsR5wFjhZo9lp+BZ/RAtPwsSrj0=",
+        "lastModified": 1747414122,
+        "narHash": "sha256-diCezyxS9//xT1a9YWWyFXpdTLcUpSbFhB7yqcVfId8=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "bbc926d6f93a7cdad1cd38dc1410cea23589a40e",
+        "rev": "763394c47f5a8fe4ae97ef0754925efac0d51ec1",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746729224,
-        "narHash": "sha256-9R4sOLAK1w3Bq54H3XOJogdc7a6C2bLLmatOQ+5pf5w=",
+        "lastModified": 1747274630,
+        "narHash": "sha256-87RJwXbfOHyzTB9LYagAQ6vOZhszCvd8Gvudu+gf3qo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "85555d27ded84604ad6657ecca255a03fd878607",
+        "rev": "ec7c109a4f794fce09aad87239eab7f66540b888",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747106332,
-        "narHash": "sha256-mOdRWJzJAMp0hF8aSResyp8BeOO5VoSng1uqtEq+8xI=",
+        "lastModified": 1747439237,
+        "narHash": "sha256-5rCGrnkglKKj4cav1U3HC+SIUNJh08pqOK4spQv9RjA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "535a541b429c1e89f0955c160df1d6d2bfeaf802",
+        "rev": "ae755329092c87369b9e9a1510a8cf1ce2b1c708",
         "type": "github"
       },
       "original": {
@@ -351,11 +351,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1746549778,
-        "narHash": "sha256-q3bZeVBcuXxfRJPP337D88C8dGoZbYZoum8xzQCVnms=",
+        "lastModified": 1747411805,
+        "narHash": "sha256-0ZzuCYc3Umi342ZEQdlq3Icm9TYi/zVPz37B3B+9MAo=",
         "owner": "ravitemer",
         "repo": "mcp-hub",
-        "rev": "9357b1b6748c14182047890d928cb7f06632fc6d",
+        "rev": "e3bce4eb6ff446a236c9a87082f9f4e0063d6f05",
         "type": "github"
       },
       "original": {
@@ -369,11 +369,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1747065827,
-        "narHash": "sha256-f0rIa92VWe1rw0EoJwtVdRnS6qIuwCzp3M71Wa/9A6M=",
+        "lastModified": 1747239605,
+        "narHash": "sha256-zwlptZAH54wCF+JNJWNF3ZmCRwvMtSsDQkgK/anWTsY=",
         "owner": "natsukium",
         "repo": "mcp-servers-nix",
-        "rev": "610bd4ebdfae8c9f686a3ead6b1e0f4661f2cd37",
+        "rev": "9689f2309fa9f0b154ddef38bdbe140b3de0daa5",
         "type": "github"
       },
       "original": {
@@ -570,11 +570,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1746904237,
-        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
+        "lastModified": 1747179050,
+        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
+        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/bbc926d6f93a7cdad1cd38dc1410cea23589a40e' (2025-05-10)
  → 'github:catppuccin/nix/763394c47f5a8fe4ae97ef0754925efac0d51ec1' (2025-05-16)
• Updated input 'disko':
    'github:nix-community/disko/85555d27ded84604ad6657ecca255a03fd878607' (2025-05-08)
  → 'github:nix-community/disko/ec7c109a4f794fce09aad87239eab7f66540b888' (2025-05-15)
• Updated input 'home-manager':
    'github:nix-community/home-manager/535a541b429c1e89f0955c160df1d6d2bfeaf802' (2025-05-13)
  → 'github:nix-community/home-manager/ae755329092c87369b9e9a1510a8cf1ce2b1c708' (2025-05-16)
• Updated input 'mcp-hub':
    'github:ravitemer/mcp-hub/9357b1b6748c14182047890d928cb7f06632fc6d' (2025-05-06)
  → 'github:ravitemer/mcp-hub/e3bce4eb6ff446a236c9a87082f9f4e0063d6f05' (2025-05-16)
• Updated input 'mcp-servers-nix':
    'github:natsukium/mcp-servers-nix/610bd4ebdfae8c9f686a3ead6b1e0f4661f2cd37' (2025-05-12)
  → 'github:natsukium/mcp-servers-nix/9689f2309fa9f0b154ddef38bdbe140b3de0daa5' (2025-05-14)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d89fc19e405cb2d55ce7cc114356846a0ee5e956' (2025-05-10)
  → 'github:nixos/nixpkgs/adaa24fbf46737f3f1b5497bf64bae750f82942e' (2025-05-13)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`85555d27` ➡️ `ec7c109a`](https://github.com/nix-community/disko/compare/85555d27ded84604ad6657ecca255a03fd878607...ec7c109a4f794fce09aad87239eab7f66540b888) <sub>(2025-05-08 to 2025-05-15)</sub>
 - Updated input [`mcp-servers-nix`](https://github.com/natsukium/mcp-servers-nix): [`610bd4eb` ➡️ `9689f230`](https://github.com/natsukium/mcp-servers-nix/compare/610bd4ebdfae8c9f686a3ead6b1e0f4661f2cd37...9689f2309fa9f0b154ddef38bdbe140b3de0daa5) <sub>(2025-05-12 to 2025-05-14)</sub>
 - Updated input [`mcp-hub`](https://github.com/ravitemer/mcp-hub): [`9357b1b6` ➡️ `e3bce4eb`](https://github.com/ravitemer/mcp-hub/compare/9357b1b6748c14182047890d928cb7f06632fc6d...e3bce4eb6ff446a236c9a87082f9f4e0063d6f05) <sub>(2025-05-06 to 2025-05-16)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`d89fc19e` ➡️ `adaa24fb`](https://github.com/nixos/nixpkgs/compare/d89fc19e405cb2d55ce7cc114356846a0ee5e956...adaa24fbf46737f3f1b5497bf64bae750f82942e) <sub>(2025-05-10 to 2025-05-13)</sub>
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`bbc926d6` ➡️ `763394c4`](https://github.com/catppuccin/nix/compare/bbc926d6f93a7cdad1cd38dc1410cea23589a40e...763394c47f5a8fe4ae97ef0754925efac0d51ec1) <sub>(2025-05-10 to 2025-05-16)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`535a541b` ➡️ `ae755329`](https://github.com/nix-community/home-manager/compare/535a541b429c1e89f0955c160df1d6d2bfeaf802...ae755329092c87369b9e9a1510a8cf1ce2b1c708) <sub>(2025-05-13 to 2025-05-16)</sub>