### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748225455,
-        "narHash": "sha256-AzlJCKaM4wbEyEpV3I/PUq5mHnib2ryEy32c+qfj6xk=",
+        "lastModified": 1748832438,
+        "narHash": "sha256-/CtyLVfNaFP7PrOPrTEuGOJBIhcBKVQ91KiEbtXJi0A=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a894f2811e1ee8d10c50560551e50d6ab3c392ba",
+        "rev": "58d6e5a83fff9982d57e0a0a994d4e5c0af441e4",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748668774,
-        "narHash": "sha256-fYk/vk4ClmvHIgnGv/5GNRiDLtNCwXo9aLq36L/x+P4=",
+        "lastModified": 1748830238,
+        "narHash": "sha256-EB+LzYHK0D5aqxZiYoPeoZoOzSAs8eqBDxm3R+6wMKU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "60e4624302d956fe94d3f7d96a560d14d70591b9",
+        "rev": "c7fdb7e90bff1a51b79c1eed458fb39e6649a82a",
         "type": "github"
       },
       "original": {
@@ -347,11 +347,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1748460289,
-        "narHash": "sha256-7doLyJBzCllvqX4gszYtmZUToxKvMUrg45EUWaUYmBg=",
+        "lastModified": 1748693115,
+        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "96ec055edbe5ee227f28cdbc3f1ddf1df5965102",
+        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/a894f2811e1ee8d10c50560551e50d6ab3c392ba?narHash=sha256-AzlJCKaM4wbEyEpV3I/PUq5mHnib2ryEy32c%2Bqfj6xk%3D' (2025-05-26)
  → 'github:nix-community/disko/58d6e5a83fff9982d57e0a0a994d4e5c0af441e4?narHash=sha256-/CtyLVfNaFP7PrOPrTEuGOJBIhcBKVQ91KiEbtXJi0A%3D' (2025-06-02)
• Updated input 'home-manager':
    'github:nix-community/home-manager/60e4624302d956fe94d3f7d96a560d14d70591b9?narHash=sha256-fYk/vk4ClmvHIgnGv/5GNRiDLtNCwXo9aLq36L/x%2BP4%3D' (2025-05-31)
  → 'github:nix-community/home-manager/c7fdb7e90bff1a51b79c1eed458fb39e6649a82a?narHash=sha256-EB%2BLzYHK0D5aqxZiYoPeoZoOzSAs8eqBDxm3R%2B6wMKU%3D' (2025-06-02)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/96ec055edbe5ee227f28cdbc3f1ddf1df5965102?narHash=sha256-7doLyJBzCllvqX4gszYtmZUToxKvMUrg45EUWaUYmBg%3D' (2025-05-28)
  → 'github:NixOS/nixpkgs/910796cabe436259a29a72e8d3f5e180fc6dfacc?narHash=sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8%3D' (2025-05-31)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`a894f281` ➡️ `58d6e5a8`](https://github.com/nix-community/disko/compare/a894f2811e1ee8d10c50560551e50d6ab3c392ba...58d6e5a83fff9982d57e0a0a994d4e5c0af441e4) <sub>(2025-05-26 to 2025-06-02)</sub>
 - Updated input [`nixpkgs`](https://github.com/NixOS/nixpkgs): [`96ec055e` ➡️ `910796ca`](https://github.com/NixOS/nixpkgs/compare/96ec055edbe5ee227f28cdbc3f1ddf1df5965102...910796cabe436259a29a72e8d3f5e180fc6dfacc) <sub>(2025-05-28 to 2025-05-31)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`60e46243` ➡️ `c7fdb7e9`](https://github.com/nix-community/home-manager/compare/60e4624302d956fe94d3f7d96a560d14d70591b9...c7fdb7e90bff1a51b79c1eed458fb39e6649a82a) <sub>(2025-05-31 to 2025-06-02)</sub>