### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748830238,
-        "narHash": "sha256-EB+LzYHK0D5aqxZiYoPeoZoOzSAs8eqBDxm3R+6wMKU=",
+        "lastModified": 1748925027,
+        "narHash": "sha256-BJ0qRIdvt5aeqm3zg/5if7b5rruG05zrSX3UpLqjDRk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c7fdb7e90bff1a51b79c1eed458fb39e6649a82a",
+        "rev": "cb809ec1ff15cf3237c6592af9bbc7e4d983e98c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/c7fdb7e90bff1a51b79c1eed458fb39e6649a82a?narHash=sha256-EB%2BLzYHK0D5aqxZiYoPeoZoOzSAs8eqBDxm3R%2B6wMKU%3D' (2025-06-02)
  → 'github:nix-community/home-manager/cb809ec1ff15cf3237c6592af9bbc7e4d983e98c?narHash=sha256-BJ0qRIdvt5aeqm3zg/5if7b5rruG05zrSX3UpLqjDRk%3D' (2025-06-03)

```

</p></details>

 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`c7fdb7e9` ➡️ `cb809ec1`](https://github.com/nix-community/home-manager/compare/c7fdb7e90bff1a51b79c1eed458fb39e6649a82a...cb809ec1ff15cf3237c6592af9bbc7e4d983e98c) <sub>(2025-06-02 to 2025-06-03)</sub>