### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748955489,
-        "narHash": "sha256-OmZXyW2g5qIuo5Te74McwR0TwauCO2sF3/SjGDVuxyg=",
+        "lastModified": 1748979197,
+        "narHash": "sha256-mKYwYcO9RmA2AcAFIXGDBOw5iv/fbjw6adWvMbnfIuk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bb846c031be68a96466b683be32704ef6e07b159",
+        "rev": "34a13086148cbb3ae65a79f753eb451ce5cac3d3",
         "type": "github"
       },
       "original": {
@@ -198,11 +198,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730695632,
-        "narHash": "sha256-JtbuSxWFR94HiUdQL9uIm2V/kwGz0gbVbqvYWmEncbc=",
+        "lastModified": 1748977843,
+        "narHash": "sha256-0gXtFVan+Urb79AjFOjHdjl3Q73m8M3wFSo3ZhjxcBA=",
         "owner": "niksingh710",
         "repo": "minimal-tmux-status",
-        "rev": "d7188c1aeb1c7dd03230982445b7360f5e230131",
+        "rev": "de2bb049a743e0f05c08531a0461f7f81da0fc72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/bb846c031be68a96466b683be32704ef6e07b159?narHash=sha256-OmZXyW2g5qIuo5Te74McwR0TwauCO2sF3/SjGDVuxyg%3D' (2025-06-03)
  → 'github:nix-community/home-manager/34a13086148cbb3ae65a79f753eb451ce5cac3d3?narHash=sha256-mKYwYcO9RmA2AcAFIXGDBOw5iv/fbjw6adWvMbnfIuk%3D' (2025-06-03)
• Updated input 'minimal-tmux':
    'github:niksingh710/minimal-tmux-status/d7188c1aeb1c7dd03230982445b7360f5e230131?narHash=sha256-JtbuSxWFR94HiUdQL9uIm2V/kwGz0gbVbqvYWmEncbc%3D' (2024-11-04)
  → 'github:niksingh710/minimal-tmux-status/de2bb049a743e0f05c08531a0461f7f81da0fc72?narHash=sha256-0gXtFVan%2BUrb79AjFOjHdjl3Q73m8M3wFSo3ZhjxcBA%3D' (2025-06-03)

```

</p></details>

 - Updated input [`minimal-tmux`](https://github.com/niksingh710/minimal-tmux-status): [`d7188c1a` ➡️ `de2bb049`](https://github.com/niksingh710/minimal-tmux-status/compare/d7188c1aeb1c7dd03230982445b7360f5e230131...de2bb049a743e0f05c08531a0461f7f81da0fc72) <sub>(2024-11-04 to 2025-06-03)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`bb846c03` ➡️ `34a13086`](https://github.com/nix-community/home-manager/compare/bb846c031be68a96466b683be32704ef6e07b159...34a13086148cbb3ae65a79f753eb451ce5cac3d3) <sub>(2025-06-03 to 2025-06-03)</sub>