### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748832438,
-        "narHash": "sha256-/CtyLVfNaFP7PrOPrTEuGOJBIhcBKVQ91KiEbtXJi0A=",
+        "lastModified": 1749089136,
+        "narHash": "sha256-A1UgwtAEQYd38Z6VoRAiGs4jZQczAGyP5DF3hhYUdpg=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "58d6e5a83fff9982d57e0a0a994d4e5c0af441e4",
+        "rev": "a4f7deb49f7336feb6c5abaf213b374936421dbe",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748979197,
-        "narHash": "sha256-mKYwYcO9RmA2AcAFIXGDBOw5iv/fbjw6adWvMbnfIuk=",
+        "lastModified": 1749062139,
+        "narHash": "sha256-gGGLujmeWU+ZjFzfMvFMI0hp9xONsSbm88187wJr82Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "34a13086148cbb3ae65a79f753eb451ce5cac3d3",
+        "rev": "86b95fc1ed2b9b04a451a08ccf13d78fb421859c",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1748942041,
-        "narHash": "sha256-HEu2gTct7nY0tAPRgBtqYepallryBKR1U8B4v2zEEqA=",
+        "lastModified": 1749056381,
+        "narHash": "sha256-QITcurR19KZlrCngBoCjsFF2BdYsiCG4UqmlrVcLb8Q=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "fc7c4714125cfaa19b048e8aaf86b9c53e04d853",
+        "rev": "029bd66faa180e11262dd1bc2732254c33415f52",
         "type": "github"
       },
       "original": {
@@ -347,11 +347,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1748693115,
-        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/58d6e5a83fff9982d57e0a0a994d4e5c0af441e4?narHash=sha256-/CtyLVfNaFP7PrOPrTEuGOJBIhcBKVQ91KiEbtXJi0A%3D' (2025-06-02)
  → 'github:nix-community/disko/a4f7deb49f7336feb6c5abaf213b374936421dbe?narHash=sha256-A1UgwtAEQYd38Z6VoRAiGs4jZQczAGyP5DF3hhYUdpg%3D' (2025-06-05)
• Updated input 'home-manager':
    'github:nix-community/home-manager/34a13086148cbb3ae65a79f753eb451ce5cac3d3?narHash=sha256-mKYwYcO9RmA2AcAFIXGDBOw5iv/fbjw6adWvMbnfIuk%3D' (2025-06-03)
  → 'github:nix-community/home-manager/86b95fc1ed2b9b04a451a08ccf13d78fb421859c?narHash=sha256-gGGLujmeWU%2BZjFzfMvFMI0hp9xONsSbm88187wJr82Q%3D' (2025-06-04)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/fc7c4714125cfaa19b048e8aaf86b9c53e04d853?narHash=sha256-HEu2gTct7nY0tAPRgBtqYepallryBKR1U8B4v2zEEqA%3D' (2025-06-03)
  → 'github:NixOS/nixos-hardware/029bd66faa180e11262dd1bc2732254c33415f52?narHash=sha256-QITcurR19KZlrCngBoCjsFF2BdYsiCG4UqmlrVcLb8Q%3D' (2025-06-04)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/910796cabe436259a29a72e8d3f5e180fc6dfacc?narHash=sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8%3D' (2025-05-31)
  → 'github:NixOS/nixpkgs/c2a03962b8e24e669fb37b7df10e7c79531ff1a4?narHash=sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj%2BQ%3D' (2025-06-03)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`58d6e5a8` ➡️ `a4f7deb4`](https://github.com/nix-community/disko/compare/58d6e5a83fff9982d57e0a0a994d4e5c0af441e4...a4f7deb49f7336feb6c5abaf213b374936421dbe) <sub>(2025-06-02 to 2025-06-05)</sub>
 - Updated input [`nixpkgs`](https://github.com/NixOS/nixpkgs): [`910796ca` ➡️ `c2a03962`](https://github.com/NixOS/nixpkgs/compare/910796cabe436259a29a72e8d3f5e180fc6dfacc...c2a03962b8e24e669fb37b7df10e7c79531ff1a4) <sub>(2025-05-31 to 2025-06-03)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`34a13086` ➡️ `86b95fc1`](https://github.com/nix-community/home-manager/compare/34a13086148cbb3ae65a79f753eb451ce5cac3d3...86b95fc1ed2b9b04a451a08ccf13d78fb421859c) <sub>(2025-06-03 to 2025-06-04)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`fc7c4714` ➡️ `029bd66f`](https://github.com/NixOS/nixos-hardware/compare/fc7c4714125cfaa19b048e8aaf86b9c53e04d853...029bd66faa180e11262dd1bc2732254c33415f52) <sub>(2025-06-03 to 2025-06-04)</sub>