### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749089136,
-        "narHash": "sha256-A1UgwtAEQYd38Z6VoRAiGs4jZQczAGyP5DF3hhYUdpg=",
+        "lastModified": 1749147380,
+        "narHash": "sha256-UvCI5f1qD9l1fCQkoG/kJI0yNjDQIiJaN7gkve8fmII=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a4f7deb49f7336feb6c5abaf213b374936421dbe",
+        "rev": "d74db625a5cf3f46cf8fa545d6ef10bd3463ea07",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749062139,
-        "narHash": "sha256-gGGLujmeWU+ZjFzfMvFMI0hp9xONsSbm88187wJr82Q=",
+        "lastModified": 1749178927,
+        "narHash": "sha256-bXcEx1aZUNm5hMLVJeuofcOrZyOiapzvQ7K36HYK3YQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "86b95fc1ed2b9b04a451a08ccf13d78fb421859c",
+        "rev": "91287a0e9d42570754487b7e38c6697e15a9aab2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/a4f7deb49f7336feb6c5abaf213b374936421dbe?narHash=sha256-A1UgwtAEQYd38Z6VoRAiGs4jZQczAGyP5DF3hhYUdpg%3D' (2025-06-05)
  → 'github:nix-community/disko/d74db625a5cf3f46cf8fa545d6ef10bd3463ea07?narHash=sha256-UvCI5f1qD9l1fCQkoG/kJI0yNjDQIiJaN7gkve8fmII%3D' (2025-06-05)
• Updated input 'home-manager':
    'github:nix-community/home-manager/86b95fc1ed2b9b04a451a08ccf13d78fb421859c?narHash=sha256-gGGLujmeWU%2BZjFzfMvFMI0hp9xONsSbm88187wJr82Q%3D' (2025-06-04)
  → 'github:nix-community/home-manager/91287a0e9d42570754487b7e38c6697e15a9aab2?narHash=sha256-bXcEx1aZUNm5hMLVJeuofcOrZyOiapzvQ7K36HYK3YQ%3D' (2025-06-06)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`a4f7deb4` ➡️ `d74db625`](https://github.com/nix-community/disko/compare/a4f7deb49f7336feb6c5abaf213b374936421dbe...d74db625a5cf3f46cf8fa545d6ef10bd3463ea07) <sub>(2025-06-05 to 2025-06-05)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`86b95fc1` ➡️ `91287a0e`](https://github.com/nix-community/home-manager/compare/86b95fc1ed2b9b04a451a08ccf13d78fb421859c...91287a0e9d42570754487b7e38c6697e15a9aab2) <sub>(2025-06-04 to 2025-06-06)</sub>