### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1748080874,
-        "narHash": "sha256-sUebEzAkrY8Aq5G0GHFyRddmRNGP/a2iTtV7ISNvi/c=",
+        "lastModified": 1749223974,
+        "narHash": "sha256-/GAQYRW1duU81KG//2wI9ax8EkHVG/e1UOD97NdwLOY=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "0ba11b12be81f0849a89ed17ab635164ea8f0112",
+        "rev": "3a42cd79c647360ee8742659e42aeec0947dd3b4",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749147380,
-        "narHash": "sha256-UvCI5f1qD9l1fCQkoG/kJI0yNjDQIiJaN7gkve8fmII=",
+        "lastModified": 1749200714,
+        "narHash": "sha256-W8KiJIrVwmf43JOPbbTu5lzq+cmdtRqaNbOsZigjioY=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d74db625a5cf3f46cf8fa545d6ef10bd3463ea07",
+        "rev": "17d08c65c241b1d65b3ddf79e3fac1ddc870b0f6",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749178927,
-        "narHash": "sha256-bXcEx1aZUNm5hMLVJeuofcOrZyOiapzvQ7K36HYK3YQ=",
+        "lastModified": 1749243446,
+        "narHash": "sha256-P1gumhZN5N9q+39ndePHYrtwOwY1cGx+VoXGl+vTm7A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "91287a0e9d42570754487b7e38c6697e15a9aab2",
+        "rev": "2d7d65f65b61fdfce23278e59ca266ddd0ef0a36",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1749056381,
-        "narHash": "sha256-QITcurR19KZlrCngBoCjsFF2BdYsiCG4UqmlrVcLb8Q=",
+        "lastModified": 1749195551,
+        "narHash": "sha256-W5GKQHgunda/OP9sbKENBZhMBDNu2QahoIPwnsF6CeM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "029bd66faa180e11262dd1bc2732254c33415f52",
+        "rev": "4602f7e1d3f197b3cb540d5accf5669121629628",
         "type": "github"
       },
       "original": {
@@ -347,11 +347,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1748929857,
-        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
+        "lastModified": 1749143949,
+        "narHash": "sha256-QuUtALJpVrPnPeozlUG/y+oIMSLdptHxb3GK6cpSVhA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
+        "rev": "d3d2d80a2191a73d1e86456a751b83aa13085d7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/0ba11b12be81f0849a89ed17ab635164ea8f0112?narHash=sha256-sUebEzAkrY8Aq5G0GHFyRddmRNGP/a2iTtV7ISNvi/c%3D' (2025-05-24)
  → 'github:catppuccin/nix/3a42cd79c647360ee8742659e42aeec0947dd3b4?narHash=sha256-/GAQYRW1duU81KG//2wI9ax8EkHVG/e1UOD97NdwLOY%3D' (2025-06-06)
• Updated input 'disko':
    'github:nix-community/disko/d74db625a5cf3f46cf8fa545d6ef10bd3463ea07?narHash=sha256-UvCI5f1qD9l1fCQkoG/kJI0yNjDQIiJaN7gkve8fmII%3D' (2025-06-05)
  → 'github:nix-community/disko/17d08c65c241b1d65b3ddf79e3fac1ddc870b0f6?narHash=sha256-W8KiJIrVwmf43JOPbbTu5lzq%2BcmdtRqaNbOsZigjioY%3D' (2025-06-06)
• Updated input 'home-manager':
    'github:nix-community/home-manager/91287a0e9d42570754487b7e38c6697e15a9aab2?narHash=sha256-bXcEx1aZUNm5hMLVJeuofcOrZyOiapzvQ7K36HYK3YQ%3D' (2025-06-06)
  → 'github:nix-community/home-manager/2d7d65f65b61fdfce23278e59ca266ddd0ef0a36?narHash=sha256-P1gumhZN5N9q%2B39ndePHYrtwOwY1cGx%2BVoXGl%2BvTm7A%3D' (2025-06-06)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/029bd66faa180e11262dd1bc2732254c33415f52?narHash=sha256-QITcurR19KZlrCngBoCjsFF2BdYsiCG4UqmlrVcLb8Q%3D' (2025-06-04)
  → 'github:NixOS/nixos-hardware/4602f7e1d3f197b3cb540d5accf5669121629628?narHash=sha256-W5GKQHgunda/OP9sbKENBZhMBDNu2QahoIPwnsF6CeM%3D' (2025-06-06)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c2a03962b8e24e669fb37b7df10e7c79531ff1a4?narHash=sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj%2BQ%3D' (2025-06-03)
  → 'github:NixOS/nixpkgs/d3d2d80a2191a73d1e86456a751b83aa13085d7d?narHash=sha256-QuUtALJpVrPnPeozlUG/y%2BoIMSLdptHxb3GK6cpSVhA%3D' (2025-06-05)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`d74db625` ➡️ `17d08c65`](https://github.com/nix-community/disko/compare/d74db625a5cf3f46cf8fa545d6ef10bd3463ea07...17d08c65c241b1d65b3ddf79e3fac1ddc870b0f6) <sub>(2025-06-05 to 2025-06-06)</sub>
 - Updated input [`nixpkgs`](https://github.com/NixOS/nixpkgs): [`c2a03962` ➡️ `d3d2d80a`](https://github.com/NixOS/nixpkgs/compare/c2a03962b8e24e669fb37b7df10e7c79531ff1a4...d3d2d80a2191a73d1e86456a751b83aa13085d7d) <sub>(2025-06-03 to 2025-06-05)</sub>
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`0ba11b12` ➡️ `3a42cd79`](https://github.com/catppuccin/nix/compare/0ba11b12be81f0849a89ed17ab635164ea8f0112...3a42cd79c647360ee8742659e42aeec0947dd3b4) <sub>(2025-05-24 to 2025-06-06)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`91287a0e` ➡️ `2d7d65f6`](https://github.com/nix-community/home-manager/compare/91287a0e9d42570754487b7e38c6697e15a9aab2...2d7d65f65b61fdfce23278e59ca266ddd0ef0a36) <sub>(2025-06-06 to 2025-06-06)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`029bd66f` ➡️ `4602f7e1`](https://github.com/NixOS/nixos-hardware/compare/029bd66faa180e11262dd1bc2732254c33415f52...4602f7e1d3f197b3cb540d5accf5669121629628) <sub>(2025-06-04 to 2025-06-06)</sub>