### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749400020,
-        "narHash": "sha256-0nTmHO8AYgRYk5v6zw5oZ3x9nh+feb+Isn7WNe318M0=",
+        "lastModified": 1749499854,
+        "narHash": "sha256-V1BgwiX8NjbRreU6LC2EzmuqFSQAHhoSeNlYJyZ40NE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2835e8ba0ad99ba86d4a5e497a962ec9fa35e48f",
+        "rev": "1df816c407d3a5090c8496c9b00170af7891f021",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/2835e8ba0ad99ba86d4a5e497a962ec9fa35e48f?narHash=sha256-0nTmHO8AYgRYk5v6zw5oZ3x9nh%2Bfeb%2BIsn7WNe318M0%3D' (2025-06-08)
  → 'github:nix-community/home-manager/1df816c407d3a5090c8496c9b00170af7891f021?narHash=sha256-V1BgwiX8NjbRreU6LC2EzmuqFSQAHhoSeNlYJyZ40NE%3D' (2025-06-09)

```

</p></details>

 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`2835e8ba` ➡️ `1df816c4`](https://github.com/nix-community/home-manager/compare/2835e8ba0ad99ba86d4a5e497a962ec9fa35e48f...1df816c407d3a5090c8496c9b00170af7891f021) <sub>(2025-06-08 to 2025-06-09)</sub>