### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749499854,
-        "narHash": "sha256-V1BgwiX8NjbRreU6LC2EzmuqFSQAHhoSeNlYJyZ40NE=",
+        "lastModified": 1749526396,
+        "narHash": "sha256-UL9F76abAk87llXOrcQRjhd5OaOclUd6MIltsqcUZmo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1df816c407d3a5090c8496c9b00170af7891f021",
+        "rev": "427c96044f11a5da50faf6adaf38c9fa47e6d044",
         "type": "github"
       },
       "original": {
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747603214,
-        "narHash": "sha256-lAblXm0VwifYCJ/ILPXJwlz0qNY07DDYdLD+9H+Wc8o=",
+        "lastModified": 1749592509,
+        "narHash": "sha256-VunQzfZFA+Y6x3wYi2UE4DEQ8qKoAZZCnZPUlSoqC+A=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8d215e1c981be3aa37e47aeabd4e61bb069548fd",
+        "rev": "50754dfaa0e24e313c626900d44ef431f3210138",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/1df816c407d3a5090c8496c9b00170af7891f021?narHash=sha256-V1BgwiX8NjbRreU6LC2EzmuqFSQAHhoSeNlYJyZ40NE%3D' (2025-06-09)
  → 'github:nix-community/home-manager/427c96044f11a5da50faf6adaf38c9fa47e6d044?narHash=sha256-UL9F76abAk87llXOrcQRjhd5OaOclUd6MIltsqcUZmo%3D' (2025-06-10)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/8d215e1c981be3aa37e47aeabd4e61bb069548fd?narHash=sha256-lAblXm0VwifYCJ/ILPXJwlz0qNY07DDYdLD%2B9H%2BWc8o%3D' (2025-05-18)
  → 'github:Mic92/sops-nix/50754dfaa0e24e313c626900d44ef431f3210138?narHash=sha256-VunQzfZFA%2BY6x3wYi2UE4DEQ8qKoAZZCnZPUlSoqC%2BA%3D' (2025-06-10)

```

</p></details>

 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`8d215e1c` ➡️ `50754dfa`](https://github.com/Mic92/sops-nix/compare/8d215e1c981be3aa37e47aeabd4e61bb069548fd...50754dfaa0e24e313c626900d44ef431f3210138) <sub>(2025-05-18 to 2025-06-10)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`1df816c4` ➡️ `427c9604`](https://github.com/nix-community/home-manager/compare/1df816c407d3a5090c8496c9b00170af7891f021...427c96044f11a5da50faf6adaf38c9fa47e6d044) <sub>(2025-06-09 to 2025-06-10)</sub>