### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749526396,
-        "narHash": "sha256-UL9F76abAk87llXOrcQRjhd5OaOclUd6MIltsqcUZmo=",
+        "lastModified": 1749993966,
+        "narHash": "sha256-Y2uGxeNL75ZxRqAB1hGRYSULKjSdNy81T5FwFep0Pjw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "427c96044f11a5da50faf6adaf38c9fa47e6d044",
+        "rev": "dceefa87dc19661186f2c519dce6a9670a1d1b36",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1749195551,
-        "narHash": "sha256-W5GKQHgunda/OP9sbKENBZhMBDNu2QahoIPwnsF6CeM=",
+        "lastModified": 1749832440,
+        "narHash": "sha256-lfxhuxAaHlYFGr8yOrAXZqdMt8PrFLzjVqH9v3lQaoY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4602f7e1d3f197b3cb540d5accf5669121629628",
+        "rev": "db030f62a449568345372bd62ed8c5be4824fa49",
         "type": "github"
       },
       "original": {
@@ -347,11 +347,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1749285348,
-        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
+        "lastModified": 1749794982,
+        "narHash": "sha256-Kh9K4taXbVuaLC0IL+9HcfvxsSUx8dPB5s5weJcc9pc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
+        "rev": "ee930f9755f58096ac6e8ca94a1887e0534e2d81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/427c96044f11a5da50faf6adaf38c9fa47e6d044?narHash=sha256-UL9F76abAk87llXOrcQRjhd5OaOclUd6MIltsqcUZmo%3D' (2025-06-10)
  → 'github:nix-community/home-manager/dceefa87dc19661186f2c519dce6a9670a1d1b36?narHash=sha256-Y2uGxeNL75ZxRqAB1hGRYSULKjSdNy81T5FwFep0Pjw%3D' (2025-06-15)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/4602f7e1d3f197b3cb540d5accf5669121629628?narHash=sha256-W5GKQHgunda/OP9sbKENBZhMBDNu2QahoIPwnsF6CeM%3D' (2025-06-06)
  → 'github:NixOS/nixos-hardware/db030f62a449568345372bd62ed8c5be4824fa49?narHash=sha256-lfxhuxAaHlYFGr8yOrAXZqdMt8PrFLzjVqH9v3lQaoY%3D' (2025-06-13)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/3e3afe5174c561dee0df6f2c2b2236990146329f?narHash=sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU%3D' (2025-06-07)
  → 'github:NixOS/nixpkgs/ee930f9755f58096ac6e8ca94a1887e0534e2d81?narHash=sha256-Kh9K4taXbVuaLC0IL%2B9HcfvxsSUx8dPB5s5weJcc9pc%3D' (2025-06-13)

```

</p></details>

 - Updated input [`nixpkgs`](https://github.com/NixOS/nixpkgs): [`3e3afe51` ➡️ `ee930f97`](https://github.com/NixOS/nixpkgs/compare/3e3afe5174c561dee0df6f2c2b2236990146329f...ee930f9755f58096ac6e8ca94a1887e0534e2d81) <sub>(2025-06-07 to 2025-06-13)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`427c9604` ➡️ `dceefa87`](https://github.com/nix-community/home-manager/compare/427c96044f11a5da50faf6adaf38c9fa47e6d044...dceefa87dc19661186f2c519dce6a9670a1d1b36) <sub>(2025-06-10 to 2025-06-15)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`4602f7e1` ➡️ `db030f62`](https://github.com/NixOS/nixos-hardware/compare/4602f7e1d3f197b3cb540d5accf5669121629628...db030f62a449568345372bd62ed8c5be4824fa49) <sub>(2025-06-06 to 2025-06-13)</sub>