### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1749223974,
-        "narHash": "sha256-/GAQYRW1duU81KG//2wI9ax8EkHVG/e1UOD97NdwLOY=",
+        "lastModified": 1750013871,
+        "narHash": "sha256-UQx3rC3QDjD/sIen51+5Juk1rqN3y/sTeMY1WinmhqQ=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "3a42cd79c647360ee8742659e42aeec0947dd3b4",
+        "rev": "fe78fa558d6603481c03eb03a946eadb970d1801",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749436314,
-        "narHash": "sha256-CqmqU5FRg5AadtIkxwu8ulDSOSoIisUMZRLlcED3Q5w=",
+        "lastModified": 1750040002,
+        "narHash": "sha256-KrC9iOVYIn6ukpVlHbqSA4hYCZ6oDyJKrcLqv4c5v84=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "dfa4d1b9c39c0342ef133795127a3af14598017a",
+        "rev": "7f1857b31522062a6a00f88cbccf86b43acceed1",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749993966,
-        "narHash": "sha256-Y2uGxeNL75ZxRqAB1hGRYSULKjSdNy81T5FwFep0Pjw=",
+        "lastModified": 1750127463,
+        "narHash": "sha256-K2xFtlD3PcKAZriOE3LaBLYmVfGQu+rIF4Jr1RFYR0Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dceefa87dc19661186f2c519dce6a9670a1d1b36",
+        "rev": "28eef8722d1af18ca13e687dbf485e1c653a0402",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1749832440,
-        "narHash": "sha256-lfxhuxAaHlYFGr8yOrAXZqdMt8PrFLzjVqH9v3lQaoY=",
+        "lastModified": 1750083401,
+        "narHash": "sha256-ynqbgIYrg7P1fAKYqe8I/PMiLABBcNDYG9YaAP/d/C4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "db030f62a449568345372bd62ed8c5be4824fa49",
+        "rev": "61837d2a33ccc1582c5fabb7bf9130d39fee59ad",
         "type": "github"
       },
       "original": {
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749592509,
-        "narHash": "sha256-VunQzfZFA+Y6x3wYi2UE4DEQ8qKoAZZCnZPUlSoqC+A=",
+        "lastModified": 1750119275,
+        "narHash": "sha256-Rr7Pooz9zQbhdVxux16h7URa6mA80Pb/G07T4lHvh0M=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "50754dfaa0e24e313c626900d44ef431f3210138",
+        "rev": "77c423a03b9b2b79709ea2cb63336312e78b72e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'catppuccin':
    'github:catppuccin/nix/3a42cd79c647360ee8742659e42aeec0947dd3b4?narHash=sha256-/GAQYRW1duU81KG//2wI9ax8EkHVG/e1UOD97NdwLOY%3D' (2025-06-06)
  → 'github:catppuccin/nix/fe78fa558d6603481c03eb03a946eadb970d1801?narHash=sha256-UQx3rC3QDjD/sIen51%2B5Juk1rqN3y/sTeMY1WinmhqQ%3D' (2025-06-15)
• Updated input 'disko':
    'github:nix-community/disko/dfa4d1b9c39c0342ef133795127a3af14598017a?narHash=sha256-CqmqU5FRg5AadtIkxwu8ulDSOSoIisUMZRLlcED3Q5w%3D' (2025-06-09)
  → 'github:nix-community/disko/7f1857b31522062a6a00f88cbccf86b43acceed1?narHash=sha256-KrC9iOVYIn6ukpVlHbqSA4hYCZ6oDyJKrcLqv4c5v84%3D' (2025-06-16)
• Updated input 'home-manager':
    'github:nix-community/home-manager/dceefa87dc19661186f2c519dce6a9670a1d1b36?narHash=sha256-Y2uGxeNL75ZxRqAB1hGRYSULKjSdNy81T5FwFep0Pjw%3D' (2025-06-15)
  → 'github:nix-community/home-manager/28eef8722d1af18ca13e687dbf485e1c653a0402?narHash=sha256-K2xFtlD3PcKAZriOE3LaBLYmVfGQu%2BrIF4Jr1RFYR0Q%3D' (2025-06-17)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/db030f62a449568345372bd62ed8c5be4824fa49?narHash=sha256-lfxhuxAaHlYFGr8yOrAXZqdMt8PrFLzjVqH9v3lQaoY%3D' (2025-06-13)
  → 'github:NixOS/nixos-hardware/61837d2a33ccc1582c5fabb7bf9130d39fee59ad?narHash=sha256-ynqbgIYrg7P1fAKYqe8I/PMiLABBcNDYG9YaAP/d/C4%3D' (2025-06-16)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/50754dfaa0e24e313c626900d44ef431f3210138?narHash=sha256-VunQzfZFA%2BY6x3wYi2UE4DEQ8qKoAZZCnZPUlSoqC%2BA%3D' (2025-06-10)
  → 'github:Mic92/sops-nix/77c423a03b9b2b79709ea2cb63336312e78b72e2?narHash=sha256-Rr7Pooz9zQbhdVxux16h7URa6mA80Pb/G07T4lHvh0M%3D' (2025-06-17)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`dfa4d1b9` ➡️ `7f1857b3`](https://github.com/nix-community/disko/compare/dfa4d1b9c39c0342ef133795127a3af14598017a...7f1857b31522062a6a00f88cbccf86b43acceed1) <sub>(2025-06-09 to 2025-06-16)</sub>
 - Updated input [`catppuccin`](https://github.com/catppuccin/nix): [`3a42cd79` ➡️ `fe78fa55`](https://github.com/catppuccin/nix/compare/3a42cd79c647360ee8742659e42aeec0947dd3b4...fe78fa558d6603481c03eb03a946eadb970d1801) <sub>(2025-06-06 to 2025-06-15)</sub>
 - Updated input [`sops-nix`](https://github.com/Mic92/sops-nix): [`50754dfa` ➡️ `77c423a0`](https://github.com/Mic92/sops-nix/compare/50754dfaa0e24e313c626900d44ef431f3210138...77c423a03b9b2b79709ea2cb63336312e78b72e2) <sub>(2025-06-10 to 2025-06-17)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`dceefa87` ➡️ `28eef872`](https://github.com/nix-community/home-manager/compare/dceefa87dc19661186f2c519dce6a9670a1d1b36...28eef8722d1af18ca13e687dbf485e1c653a0402) <sub>(2025-06-15 to 2025-06-17)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`db030f62` ➡️ `61837d2a`](https://github.com/NixOS/nixos-hardware/compare/db030f62a449568345372bd62ed8c5be4824fa49...61837d2a33ccc1582c5fabb7bf9130d39fee59ad) <sub>(2025-06-13 to 2025-06-16)</sub>