### PR TITLE
chore(flake): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750040002,
-        "narHash": "sha256-KrC9iOVYIn6ukpVlHbqSA4hYCZ6oDyJKrcLqv4c5v84=",
+        "lastModified": 1750903843,
+        "narHash": "sha256-Ng9+f0H5/dW+mq/XOKvB9uwvGbsuiiO6HrPdAcVglCs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "7f1857b31522062a6a00f88cbccf86b43acceed1",
+        "rev": "83c4da299c1d7d300f8c6fd3a72ac46cb0d59aae",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750304462,
-        "narHash": "sha256-Mj5t4yX05/rXnRqJkpoLZTWqgStB88Mr/fegTRqyiWc=",
+        "lastModified": 1750973805,
+        "narHash": "sha256-BZXgag7I0rnL/HMHAsBz3tQrfKAibpY2vovexl2lS+Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "863842639722dd12ae9e37ca83bcb61a63b36f6c",
+        "rev": "080e8b48b0318b38143d5865de9334f46d51fce3",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1750083401,
-        "narHash": "sha256-ynqbgIYrg7P1fAKYqe8I/PMiLABBcNDYG9YaAP/d/C4=",
+        "lastModified": 1750837715,
+        "narHash": "sha256-2m1ceZjbmgrJCZ2PuQZaK4in3gcg3o6rZ7WK6dr5vAA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "61837d2a33ccc1582c5fabb7bf9130d39fee59ad",
+        "rev": "98236410ea0fe204d0447149537a924fb71a6d4f",
         "type": "github"
       },
       "original": {
@@ -347,11 +347,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1750134718,
-        "narHash": "sha256-v263g4GbxXv87hMXMCpjkIxd/viIF7p3JpJrwgKdNiI=",
+        "lastModified": 1750776420,
+        "narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e83b64f727c88a7711a2c463a7b16eedb69a84c",
+        "rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/7f1857b31522062a6a00f88cbccf86b43acceed1?narHash=sha256-KrC9iOVYIn6ukpVlHbqSA4hYCZ6oDyJKrcLqv4c5v84%3D' (2025-06-16)
  → 'github:nix-community/disko/83c4da299c1d7d300f8c6fd3a72ac46cb0d59aae?narHash=sha256-Ng9%2Bf0H5/dW%2Bmq/XOKvB9uwvGbsuiiO6HrPdAcVglCs%3D' (2025-06-26)
• Updated input 'home-manager':
    'github:nix-community/home-manager/863842639722dd12ae9e37ca83bcb61a63b36f6c?narHash=sha256-Mj5t4yX05/rXnRqJkpoLZTWqgStB88Mr/fegTRqyiWc%3D' (2025-06-19)
  → 'github:nix-community/home-manager/080e8b48b0318b38143d5865de9334f46d51fce3?narHash=sha256-BZXgag7I0rnL/HMHAsBz3tQrfKAibpY2vovexl2lS%2BY%3D' (2025-06-26)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/61837d2a33ccc1582c5fabb7bf9130d39fee59ad?narHash=sha256-ynqbgIYrg7P1fAKYqe8I/PMiLABBcNDYG9YaAP/d/C4%3D' (2025-06-16)
  → 'github:NixOS/nixos-hardware/98236410ea0fe204d0447149537a924fb71a6d4f?narHash=sha256-2m1ceZjbmgrJCZ2PuQZaK4in3gcg3o6rZ7WK6dr5vAA%3D' (2025-06-25)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/9e83b64f727c88a7711a2c463a7b16eedb69a84c?narHash=sha256-v263g4GbxXv87hMXMCpjkIxd/viIF7p3JpJrwgKdNiI%3D' (2025-06-17)
  → 'github:NixOS/nixpkgs/30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf?narHash=sha256-/CG%2Bw0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A%3D' (2025-06-24)

```

</p></details>

 - Updated input [`disko`](https://github.com/nix-community/disko): [`7f1857b3` ➡️ `83c4da29`](https://github.com/nix-community/disko/compare/7f1857b31522062a6a00f88cbccf86b43acceed1...83c4da299c1d7d300f8c6fd3a72ac46cb0d59aae) <sub>(2025-06-16 to 2025-06-26)</sub>
 - Updated input [`nixpkgs`](https://github.com/NixOS/nixpkgs): [`9e83b64f` ➡️ `30a61f05`](https://github.com/NixOS/nixpkgs/compare/9e83b64f727c88a7711a2c463a7b16eedb69a84c...30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf) <sub>(2025-06-17 to 2025-06-24)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`86384263` ➡️ `080e8b48`](https://github.com/nix-community/home-manager/compare/863842639722dd12ae9e37ca83bcb61a63b36f6c...080e8b48b0318b38143d5865de9334f46d51fce3) <sub>(2025-06-19 to 2025-06-26)</sub>
 - Updated input [`nixos-hardware`](https://github.com/NixOS/nixos-hardware): [`61837d2a` ➡️ `98236410`](https://github.com/NixOS/nixos-hardware/compare/61837d2a33ccc1582c5fabb7bf9130d39fee59ad...98236410ea0fe204d0447149537a924fb71a6d4f) <sub>(2025-06-16 to 2025-06-25)</sub>